### PR TITLE
CRS-628 Moving container id to secrets.

### DIFF
--- a/helm_deploy/calculate-release-dates/values.yaml
+++ b/helm_deploy/calculate-release-dates/values.yaml
@@ -43,6 +43,7 @@ generic-service:
       SYSTEM_CLIENT_ID: "SYSTEM_CLIENT_ID"
       SYSTEM_CLIENT_SECRET: "SYSTEM_CLIENT_SECRET"
       SESSION_SECRET: "SESSION_SECRET"
+      TAG_MANAGER_CONTAINER_ID: "TAG_MANAGER_CONTAINER_ID"
     elasticache-redis:
       REDIS_HOST: "primary_endpoint_address"
       REDIS_AUTH_TOKEN: "auth_token"

--- a/server/config.ts
+++ b/server/config.ts
@@ -96,4 +96,7 @@ export default {
     },
   },
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
+  analytics: {
+    tagManagerContainerId: get('TAG_MANAGER_CONTAINER_ID', ''),
+  },
 }

--- a/server/routes/calculationRoutes.ts
+++ b/server/routes/calculationRoutes.ts
@@ -13,29 +13,6 @@ export default class CalculationRoutes {
     private readonly entryPointService: EntryPointService
   ) {}
 
-  public submitCheckInformation: RequestHandler = async (req, res): Promise<void> => {
-    const { username, caseloads, token } = res.locals.user
-    const { nomsId } = req.params
-
-    const prisonerDetail = await this.prisonerService.getPrisonerDetail(username, nomsId, caseloads, token)
-    const sentencesAndOffences = await this.prisonerService.getSentencesAndOffences(
-      username,
-      prisonerDetail.bookingId,
-      token
-    )
-    const errors = this.calculateReleaseDatesService.validateNomisInformation(sentencesAndOffences)
-    if (errors.messages.length > 0) {
-      return res.redirect(`/calculation/${nomsId}/check-information?hasErrors=true`)
-    }
-
-    const releaseDates = await this.calculateReleaseDatesService.calculatePreliminaryReleaseDates(
-      username,
-      nomsId,
-      token
-    )
-    return res.redirect(`/calculation/${nomsId}/summary/${releaseDates.calculationRequestId}`)
-  }
-
   public calculationSummary: RequestHandler = async (req, res): Promise<void> => {
     const { username, caseloads, token } = res.locals.user
     const { nomsId } = req.params

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -3,6 +3,7 @@ import nunjucks from 'nunjucks'
 import express from 'express'
 import * as pathModule from 'path'
 import { PrisonApiOffenderSentenceAndOffences } from '../@types/prisonApi/prisonClientTypes'
+import config from '../config'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const dateFilter = require('nunjucks-date-filter')
@@ -40,6 +41,13 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
       express: app,
     }
   )
+
+  // Expose the google tag manager container ID to the nunjucks environment
+  const {
+    analytics: { tagManagerContainerId },
+  } = config
+
+  njkEnv.addGlobal('tagManagerContainerId', tagManagerContainerId)
 
   njkEnv.addFilter('initialiseName', (fullName: string) => {
     // this check is for the authError page

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -4,29 +4,31 @@
 
 {% block head %}
 
-  <!-- Google Tag Manager -->
-  <script nonce="{{cspNonce}}">
-    ;
-    (function (w, d, s, l, i) {
-      w[l] = w[l] || [];
-      w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-      var f = d.getElementsByTagName(s)[0],
-        j = d.createElement(s),
-        dl = l != 'dataLayer'
-          ? '&l=' + l
-          : '';
+  {% if tagManagerContainerId %}
+    <!-- Google Tag Manager -->
+    <script nonce="{{cspNonce}}">
+      ;
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer'
+            ? '&l=' + l
+            : '';
 
-      j.async = true;
-      j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl + '{{ tagManagerEnvironment | safe }}';
+        j.async = true;
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl + '{{ tagManagerEnvironment | safe }}';
 
-      var n = d.querySelector('[nonce]');
-      n && j.setAttribute('nonce', n.nonce || n.getAttribute('nonce'));
-      f
-        .parentNode
-        .insertBefore(j, f);
-    })(window, document, 'script', 'dataLayer', 'GTM-KRZDR45');
-  </script>
-  <!-- End Google Tag Manager -->
+        var n = d.querySelector('[nonce]');
+        n && j.setAttribute('nonce', n.nonce || n.getAttribute('nonce'));
+        f
+          .parentNode
+          .insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', '{{tagManagerContainerId}}');
+    </script>
+    <!-- End Google Tag Manager -->
+  {% endif %}
 
   <!--[if !IE 8]><!-->
   <link href="/assets/stylesheets/application.css?{{ version }}" rel="stylesheet"/>


### PR DESCRIPTION
Moving the GTM container id to secrets. This will stop GA loading on dev machines and allow env specific GA config (if required in the future)