### PR TITLE
Set session timeout default to 20 minutes

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -42,7 +42,7 @@ export default {
   },
   session: {
     secret: get('SESSION_SECRET', 'app-insecure-default-session', requiredInProduction),
-    expiryMinutes: Number(get('WEB_SESSION_TIMEOUT_IN_MINUTES', 120)),
+    expiryMinutes: Number(get('WEB_SESSION_TIMEOUT_IN_MINUTES', 20)),
   },
   apis: {
     hmppsAuth: {


### PR DESCRIPTION
 in line with the penetration test report
 
 An example of another project doing session timeouts from 120 minutes to 20 minutes:
 https://github.com/ministryofjustice/book-a-prison-visit-staff-ui/pull/97/files
 
 Link to the ticket being progressed: https://dsdmoj.atlassian.net/browse/CRS-798

