### PR TITLE
CRS-1754: Update release dates mismatch table to display a "NOT APPLI…

### DIFF
--- a/server/models/ComparisonResultMismatchDetailModel.ts
+++ b/server/models/ComparisonResultMismatchDetailModel.ts
@@ -16,6 +16,8 @@ export default class ComparisonResultMismatchDetailModel {
 
   activeSexOffender?: string
 
+  mismatchType: string
+
   constructor(comparisonPerson: ComparisonPersonOverview) {
     this.nomisReference = comparisonPerson.personId
     this.bookingId = comparisonPerson.bookingId
@@ -25,6 +27,7 @@ export default class ComparisonResultMismatchDetailModel {
       comparisonPerson.breakdownByReleaseDateType
     )
     this.activeSexOffender = this.isActiveSexOffender(comparisonPerson)
+    this.mismatchType = comparisonPerson.mismatchType
     this.dates = [
       this.createDateRow(
         'SED',
@@ -165,24 +168,32 @@ export default class ComparisonResultMismatchDetailModel {
     crdsDateKey: string = ''
   ): ({ text: string } | { html: string })[] {
     if (crdsDates[crdsDateKey] || crdsDates[key] || nomisDates[key] || overrideDates[key]) {
-      return [
-        { text: key },
-        {
+      const dateRow: ({ text: string } | { html: string })[] = [{ text: key }]
+      if (this.mismatchType !== 'VALIDATION_ERROR') {
+        dateRow.push({
           html: this.displayMismatchLabel(
+            key,
             crdsDates[crdsDateKey] ?? crdsDates[key],
             nomisDates[key],
             overrideDates[key] ?? ''
           ),
-        },
+        })
+      }
+      dateRow.push(
         { text: crdsDates[crdsDateKey] ?? crdsDates[key] ?? '' },
         { text: nomisDates[key] ?? '' },
-        { text: overrideDates[key] ?? '' },
-      ]
+        { text: overrideDates[key] ?? '' }
+      )
+      return dateRow
     }
     return undefined
   }
 
-  private displayMismatchLabel(crdsDate: string, nomisDate: string, overrideDate: string) {
+  private displayMismatchLabel(key: string, crdsDate: string, nomisDate: string, overrideDate: string) {
+    const datesNotApplicableForMatch = ['HDCAD', 'APD', 'ROTL', 'ESED']
+    if (datesNotApplicableForMatch.includes(key)) {
+      return this.notApplicableLabel()
+    }
     if (crdsDate === overrideDate) {
       return this.matchLabel()
     }
@@ -198,6 +209,10 @@ export default class ComparisonResultMismatchDetailModel {
 
   private mismatchLabel() {
     return '<strong class="govuk-tag"> Mismatch </strong>'
+  }
+
+  private notApplicableLabel() {
+    return '<strong class="govuk-tag  govuk-tag--orange"> Not Applicable </strong>'
   }
 
   private isHdced14DayRule(

--- a/server/views/pages/compare/releaseDatesMismatchTable.njk
+++ b/server/views/pages/compare/releaseDatesMismatchTable.njk
@@ -1,28 +1,39 @@
+{% set headings = [
+        {
+            text: "Date",
+            classes: "govuk-!-width-one-fifth"
+        }
+    ]
+%}
+
+{% if bulkComparison.mismatchType !== 'VALIDATION_ERROR' %}
+    {% set headings = (headings.push(
+        {
+            text: "Mismatch",
+            classes: "govuk-!-width-one-fifth"
+        }), headings)
+     %}
+{% endif %}
+
+{% set headings = (headings.push(
+    {
+        text: "CRDS",
+        classes: "govuk-!-width-one-fifth"
+    },
+    {
+        text: "NOMIS",
+        classes: "govuk-!-width-one-fifth"
+    },
+    {
+        text: "User Override",
+        classes: "govuk-!-width-one-fifth"
+    }), headings)
+%}
+
 {{ govukTable({
     caption: "Release Dates",
     captionClasses: "govuk-table__caption--l",
     firstCellIsHeader: true,
-    head: [
-        {
-            text: "Date",
-            classes: "govuk-!-width-one-fifth"
-        },
-        {
-            text: "Mismatch",
-            classes: "govuk-!-width-one-fifth"
-        },
-        {
-            text: "CRDS",
-            classes: "govuk-!-width-one-fifth"
-        },
-        {
-            text: "NOMIS",
-            classes: "govuk-!-width-one-fifth"
-        },
-        {
-            text: "User Override",
-            classes: "govuk-!-width-one-fifth"
-        }
-    ],
+    head: headings,
     rows: bulkComparison.dates
 }) }}

--- a/server/views/pages/compare/resultDetail.njk
+++ b/server/views/pages/compare/resultDetail.njk
@@ -104,7 +104,9 @@
                 ]
             }) }}
 
-            {% include "./releaseDatesMismatchTable.njk" %}
+            {% if bulkComparison.mismatchType !== 'UNSUPPORTED_SENTENCE_TYPE' %}
+                {% include "./releaseDatesMismatchTable.njk" %}
+            {% endif %}
 
             {% include "./recordDiscrepencyPanel.njk" %}
 


### PR DESCRIPTION
…CABLE" tag for some date types. Don't display the dates mismatch table for un supported sentences and remove all tags for validation error mismatches.