### PR TITLE
Bump required node and npm versions in build.md

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -2,9 +2,9 @@
 
 Ensure you have the appropriate tools installed:
 
-`node >= v19`
+`node >= v20`
 
-`npm >= v9.2.0`
+`npm >= v10`
 
 Then:
 


### PR DESCRIPTION
* Versions referenced in `build.md` were a little behind package.json