### PR TITLE
CRS-1788 Fix HDC4+ BC plus missing dates

### DIFF
--- a/server/@types/calculateReleaseDates/index.d.ts
+++ b/server/@types/calculateReleaseDates/index.d.ts
@@ -668,6 +668,7 @@ export interface components {
       numberOfPeopleCompared: number
       mismatches: components['schemas']['ComparisonMismatchSummary'][]
       status: string
+      hdc4PlusCalculated: components['schemas']['ComparisonMismatchSummary'][]
     }
     ComparisonPersonOverview: {
       personId: string

--- a/server/models/ComparisonResultOverviewModel.ts
+++ b/server/models/ComparisonResultOverviewModel.ts
@@ -78,8 +78,10 @@ export default class ComparisonResultOverviewModel {
       .filter(mismatch => validationErrorMismatchTypes.includes(mismatch.misMatchType))
       .sort((a, b) => a.personId.localeCompare(b.personId))
       .map(mismatch => new ComparisonResultMismatch(mismatch, comparison.comparisonShortReference, comparisonType))
+
     this.status = comparison.status
-    this.hdced4PlusMismatches = comparison.mismatches
+
+    this.hdced4PlusMismatches = comparison.hdc4PlusCalculated
       .filter(mismatch => !['VALIDATION_ERROR', 'VALIDATION_ERROR_HDC4_PLUS'].includes(mismatch.misMatchType))
       .filter(mismatch => !!mismatch.hdcedFourPlusDate)
       .sort((a, b) => {

--- a/server/routes/compareRoutes.test.ts
+++ b/server/routes/compareRoutes.test.ts
@@ -38,6 +38,7 @@ const comparisonOverview = {
   numberOfPeopleCompared: 10,
   numberOfMismatches: 0,
   mismatches: [],
+  hdc4PlusCalculated: [],
 } as ComparisonOverview
 
 describe('Compare routes tests', () => {


### PR DESCRIPTION
* Some calculated HDCED4+ dates that were calculated were not being displayed due to them not being included in the mismatch results.