### PR TITLE
CRS-1819 - Routes for new CCARD landing page and feature toggle

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -34,6 +34,7 @@ generic-service:
     HDC4_PLUS_COMPARISON_TAB_ENABLED: "true"
     CALCULATION_REASON_TOGGLE: "true"
     ERS2024_BANNER_ENABLED: "true"
+    USE_CCARD_LAYOUT: "false"
     ENVIRONMENT_NAME: DEV
   # Switches off the allow list in the DEV env only.
   allowlist: null

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -24,7 +24,7 @@ generic-service:
     DIGITAL_PRISON_SERVICES_URL: "https://digital-dev.prison.service.justice.gov.uk"
     MANUAL_ENTRY_TOGGLE: "true"
     APPROVED_DATES_TOGGLE: "true"
-    DPS_BANNER_ENABLED: "false"
+    DPS_BANNER_ENABLED: "true"
     SPECIALIST_SUPPORT_ENABLED: "true"
     COMPONENT_API_URL: "https://frontend-components-dev.hmpps.service.justice.gov.uk"
     NON_FRIDAY_RELEASE_TOGGLE: "true"
@@ -34,7 +34,7 @@ generic-service:
     HDC4_PLUS_COMPARISON_TAB_ENABLED: "true"
     CALCULATION_REASON_TOGGLE: "true"
     ERS2024_BANNER_ENABLED: "true"
-    USE_CCARD_LAYOUT: "false"
+    USE_CCARD_LAYOUT: "true"
     ENVIRONMENT_NAME: DEV
   # Switches off the allow list in the DEV env only.
   allowlist: null

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -33,6 +33,7 @@ generic-service:
     CALCULATION_REASON_TOGGLE: "false"
     HDC4_PLUS_COMPARISON_TAB_ENABLED: "true"
     ERS2024_BANNER_ENABLED: "true"
+    USE_CCARD_LAYOUT: "false"
     ENVIRONMENT_NAME: PRE-PRODUCTION
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -27,5 +27,6 @@ generic-service:
     CALCULATION_REASON_TOGGLE: "false"
     HDC4_PLUS_COMPARISON_TAB_ENABLED: "false"
     ERS2024_BANNER_ENABLED: "true"
+    USE_CCARD_LAYOUT: "false"
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/server/config.ts
+++ b/server/config.ts
@@ -137,6 +137,7 @@ export default {
     calculationReasonToggle: get('CALCULATION_REASON_TOGGLE', false) === 'true',
     hdc4ComparisonTabEnabled: get('HDC4_PLUS_COMPARISON_TAB_ENABLED', false) === 'true',
     ers2024BannerEnabled: get('ERS2024_BANNER_ENABLED', false) === 'true',
+    useCCARDLayout: get('USE_CCARD_LAYOUT', false) === 'true',
   },
   environmentName: get('ENVIRONMENT_NAME', ''),
 }

--- a/server/routes/startRoutes.test.ts
+++ b/server/routes/startRoutes.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest'
 import type { Express } from 'express'
 import * as cheerio from 'cheerio'
-import { appWithAllRoutes, user } from './testutils/appSetup'
+import { appWithAllRoutes } from './testutils/appSetup'
 import EntryPointService from '../services/entryPointService'
 import PrisonerService from '../services/prisonerService'
 import {
@@ -54,18 +54,13 @@ const stubbedPrisonerData = {
 let app: Express
 
 beforeEach(() => {
-  app = appWithCustomUser(user)
+  app = appWithAllRoutes({
+    services: { entryPointService, prisonerService, userPermissionsService },
+  })
 })
 afterEach(() => {
   jest.resetAllMocks()
 })
-
-function appWithCustomUser(customUser: Express.User) {
-  return appWithAllRoutes({
-    services: { entryPointService, prisonerService, userPermissionsService },
-    userSupplier: () => customUser,
-  })
-}
 
 describe('Start routes tests', () => {
   it('GET / should return start page in standalone journey', () => {

--- a/server/routes/startRoutes.test.ts
+++ b/server/routes/startRoutes.test.ts
@@ -1,5 +1,6 @@
 import request from 'supertest'
 import type { Express } from 'express'
+import * as cheerio from 'cheerio'
 import { appWithAllRoutes, user } from './testutils/appSetup'
 import EntryPointService from '../services/entryPointService'
 import PrisonerService from '../services/prisonerService'
@@ -118,7 +119,15 @@ describe('Start routes tests', () => {
       .expect(200)
       .expect('Content-Type', /html/)
       .expect(res => {
-        expect(res.text).toContain('Calculations and release dates')
+        const $ = cheerio.load(res.text)
+        expect($('[data-qa=main-heading]').text()).toStrictEqual('Calculations and release dates')
+        expectMiniProfile(res.text, {
+          name: 'Anon Nobody',
+          dob: '24 June 2000',
+          prisonNumber: 'A1234AA',
+          establishment: 'Foo Prison (HMP)',
+          location: 'D-2-003',
+        })
       })
       .expect(() => {
         expect(entryPointService.setDpsEntrypointCookie.mock.calls.length).toBe(1)

--- a/server/routes/startRoutes.test.ts
+++ b/server/routes/startRoutes.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../@types/prisonApi/prisonClientTypes'
 import UserPermissionsService from '../services/userPermissionsService'
 import { expectMiniProfile, expectNoMiniProfile } from './testutils/layoutExpectations'
+import config from '../config'
 
 jest.mock('../services/entryPointService')
 jest.mock('../services/prisonerService')
@@ -82,8 +83,8 @@ describe('Start routes tests', () => {
         expect(entryPointService.setDpsEntrypointCookie.mock.calls.length).toBe(0)
       })
   })
-  it('GET ?prisonId=123 should return start page in DPS journey if user has only CRD roles', () => {
-    userPermissionsService.hasAccessToAdjustments.mockReturnValue(false)
+  it('GET ?prisonId=123 should return start page in DPS journey if CCARD feature toggle is off', () => {
+    config.featureToggles.useCCARDLayout = false
     prisonerService.getPrisonerDetail.mockResolvedValue(stubbedPrisonerData)
     return request(app)
       .get('?prisonId=123')
@@ -107,9 +108,9 @@ describe('Start routes tests', () => {
         expect(prisonerService.getPrisonerDetail).toBeCalledTimes(1)
       })
   })
-  it('GET ?prisonId=123 should return start page in CCARD journey if user has adjustments roles', () => {
+  it('GET ?prisonId=123 should return start page in CCARD journey if CCARD feature toggle is on', () => {
     userPermissionsService.allowBulkLoad.mockReturnValue(true)
-    userPermissionsService.hasAccessToAdjustments.mockReturnValue(true)
+    config.featureToggles.useCCARDLayout = true
 
     prisonerService.getPrisonerDetail.mockResolvedValue(stubbedPrisonerData)
     return request(app)

--- a/server/routes/startRoutes.ts
+++ b/server/routes/startRoutes.ts
@@ -20,9 +20,7 @@ export default class StartRoutes {
       this.entryPointService.setDpsEntrypointCookie(res, prisonId)
       const { username, caseloads, token } = res.locals.user
       const prisonerDetail = await this.prisonerService.getPrisonerDetail(username, prisonId, caseloads, token)
-      const template = this.userPermissionsService.hasAccessToAdjustments(res.locals.user.userRoles)
-        ? 'pages/ccardIndex'
-        : 'pages/index'
+      const template = config.featureToggles.useCCARDLayout ? 'pages/ccardIndex' : 'pages/index'
       return res.render(
         template,
         indexViewModelForPrisoner(prisonerDetail, prisonId, config.featureToggles.calculationReasonToggle),

--- a/server/routes/startRoutes.ts
+++ b/server/routes/startRoutes.ts
@@ -20,8 +20,11 @@ export default class StartRoutes {
       this.entryPointService.setDpsEntrypointCookie(res, prisonId)
       const { username, caseloads, token } = res.locals.user
       const prisonerDetail = await this.prisonerService.getPrisonerDetail(username, prisonId, caseloads, token)
+      const template = this.userPermissionsService.hasAccessToAdjustments(res.locals.user.userRoles)
+        ? 'pages/ccardIndex'
+        : 'pages/index'
       return res.render(
-        'pages/index',
+        template,
         indexViewModelForPrisoner(prisonerDetail, prisonId, config.featureToggles.calculationReasonToggle),
       )
     }

--- a/server/services/userPermissionsService.test.ts
+++ b/server/services/userPermissionsService.test.ts
@@ -2,56 +2,84 @@ import UserPermissionsService from './userPermissionsService'
 import AuthorisedRoles from '../enumerations/authorisedRoles'
 
 const userPermissionsService = new UserPermissionsService()
-describe('calculatePreliminaryReleaseDates', () => {
-  it('Test that people with no roles is invalid', async () => {
-    const isAllowed = userPermissionsService.allowBulkLoad([])
-    expect(isAllowed).toBeFalsy()
-  })
+describe('UserPermissionService', () => {
+  describe('allowBulkLoad', () => {
+    it('Test that people with no roles is invalid', async () => {
+      const isAllowed = userPermissionsService.allowBulkLoad([])
+      expect(isAllowed).toBeFalsy()
+    })
 
-  it('Test that people with no valid roles is invalid', async () => {
-    const isAllowed = userPermissionsService.allowBulkLoad(['NOT_A_VALID_BULK_ROLE'])
-    expect(isAllowed).toBeFalsy()
-  })
+    it('Test that people with no valid roles is invalid', async () => {
+      const isAllowed = userPermissionsService.allowBulkLoad(['NOT_A_VALID_BULK_ROLE'])
+      expect(isAllowed).toBeFalsy()
+    })
 
-  it('Test that people with RELEASE_DATE_COMPARER role are valid', async () => {
-    const isAllowed = userPermissionsService.allowBulkLoad([AuthorisedRoles.ROLE_RELEASE_DATE_COMPARER])
-    expect(isAllowed).toBeTruthy()
-  })
+    it('Test that people with RELEASE_DATE_COMPARER role are valid', async () => {
+      const isAllowed = userPermissionsService.allowBulkLoad([AuthorisedRoles.ROLE_RELEASE_DATE_COMPARER])
+      expect(isAllowed).toBeTruthy()
+    })
 
-  it('Test that people with ROLE_RELEASE_DATE_MANUAL_COMPARER role are valid', async () => {
-    const isAllowed = userPermissionsService.allowBulkLoad([AuthorisedRoles.ROLE_RELEASE_DATE_MANUAL_COMPARER])
-    expect(isAllowed).toBeTruthy()
-  })
+    it('Test that people with ROLE_RELEASE_DATE_MANUAL_COMPARER role are valid', async () => {
+      const isAllowed = userPermissionsService.allowBulkLoad([AuthorisedRoles.ROLE_RELEASE_DATE_MANUAL_COMPARER])
+      expect(isAllowed).toBeTruthy()
+    })
 
-  it('Test that people with both ROLE_RELEASE_DATE_MANUAL_COMPARER role are valid', async () => {
-    const isAllowed = userPermissionsService.allowBulkLoad([
-      AuthorisedRoles.ROLE_RELEASE_DATE_MANUAL_COMPARER,
-      AuthorisedRoles.ROLE_RELEASE_DATE_COMPARER,
-    ])
-    expect(isAllowed).toBeTruthy()
+    it('Test that people with both ROLE_RELEASE_DATE_MANUAL_COMPARER role are valid', async () => {
+      const isAllowed = userPermissionsService.allowBulkLoad([
+        AuthorisedRoles.ROLE_RELEASE_DATE_MANUAL_COMPARER,
+        AuthorisedRoles.ROLE_RELEASE_DATE_COMPARER,
+      ])
+      expect(isAllowed).toBeTruthy()
+    })
   })
+  describe('allowManualComparison', () => {
+    it('Test that people with no roles is invalid', async () => {
+      const isAllowed = userPermissionsService.allowManualComparison([])
+      expect(isAllowed).toBeFalsy()
+    })
 
-  it('Test that people with no roles is invalid', async () => {
-    const isAllowed = userPermissionsService.allowManualComparison([])
-    expect(isAllowed).toBeFalsy()
-  })
+    it('Test that people with no valid roles is invalid', async () => {
+      const isAllowed = userPermissionsService.allowManualComparison(['NOT_A_VALID_BULK_ROLE'])
+      expect(isAllowed).toBeFalsy()
+    })
 
-  it('Test that people with no valid roles is invalid', async () => {
-    const isAllowed = userPermissionsService.allowManualComparison(['NOT_A_VALID_BULK_ROLE'])
-    expect(isAllowed).toBeFalsy()
-  })
+    it('Test that people with RELEASE_DATE_COMPARER role are invalid', async () => {
+      const isAllowed = userPermissionsService.allowManualComparison([AuthorisedRoles.ROLE_RELEASE_DATE_COMPARER])
+      expect(isAllowed).toBeFalsy()
+    })
 
-  it('Test that people with RELEASE_DATE_COMPARER role are invalid', async () => {
-    const isAllowed = userPermissionsService.allowManualComparison([AuthorisedRoles.ROLE_RELEASE_DATE_COMPARER])
-    expect(isAllowed).toBeFalsy()
+    it('Test that people with ROLE_RELEASE_DATE_MANUAL_COMPARER role are valid', async () => {
+      const isAllowed = userPermissionsService.allowManualComparison([
+        AuthorisedRoles.ROLE_RELEASE_DATE_MANUAL_COMPARER,
+      ])
+      expect(isAllowed).toBeTruthy()
+    })
   })
-
-  it('Test that people with ROLE_RELEASE_DATE_MANUAL_COMPARER role are valid', async () => {
-    const isAllowed = userPermissionsService.allowManualComparison([AuthorisedRoles.ROLE_RELEASE_DATE_MANUAL_COMPARER])
-    expect(isAllowed).toBeTruthy()
+  describe('allowSpecialSupport', () => {
+    it('Test that people with ROLE_CRDS_SPECIALIST_SUPPORT role are valid', async () => {
+      const isAllowed = userPermissionsService.allowSpecialSupport([AuthorisedRoles.ROLE_CRDS_SPECIALIST_SUPPORT])
+      expect(isAllowed).toBeTruthy()
+    })
   })
-  it('Test that people with ROLE_CRDS_SPECIALIST_SUPPORT role are valid', async () => {
-    const isAllowed = userPermissionsService.allowSpecialSupport([AuthorisedRoles.ROLE_CRDS_SPECIALIST_SUPPORT])
-    expect(isAllowed).toBeTruthy()
+  describe('hasAccessToAdjustments', () => {
+    it('Test that people with ROLE_ADJUSTMENTS_MAINTAINER and ROLE_RELEASE_DATES_CALCULATOR are valid', async () => {
+      const hasAccess = userPermissionsService.hasAccessToAdjustments([
+        'ROLE_RELEASE_DATES_CALCULATOR',
+        'ROLE_ADJUSTMENTS_MAINTAINER',
+      ])
+      expect(hasAccess).toBeTruthy()
+    })
+    it('Test that people with only ROLE_ADJUSTMENTS_MAINTAINER are valid', async () => {
+      const hasAccess = userPermissionsService.hasAccessToAdjustments(['ROLE_ADJUSTMENTS_MAINTAINER'])
+      expect(hasAccess).toBeTruthy()
+    })
+    it('Test that people with only ROLE_RELEASE_DATES_CALCULATOR are not valid', async () => {
+      const hasAccess = userPermissionsService.hasAccessToAdjustments(['ROLE_RELEASE_DATES_CALCULATOR'])
+      expect(hasAccess).toBeFalsy()
+    })
+    it('Test that people with no roles are not valid', async () => {
+      const hasAccess = userPermissionsService.hasAccessToAdjustments([])
+      expect(hasAccess).toBeFalsy()
+    })
   })
 })

--- a/server/services/userPermissionsService.test.ts
+++ b/server/services/userPermissionsService.test.ts
@@ -61,25 +61,4 @@ describe('UserPermissionService', () => {
       expect(isAllowed).toBeTruthy()
     })
   })
-  describe('hasAccessToAdjustments', () => {
-    it('Test that people with ROLE_ADJUSTMENTS_MAINTAINER and ROLE_RELEASE_DATES_CALCULATOR are valid', async () => {
-      const hasAccess = userPermissionsService.hasAccessToAdjustments([
-        'ROLE_RELEASE_DATES_CALCULATOR',
-        'ROLE_ADJUSTMENTS_MAINTAINER',
-      ])
-      expect(hasAccess).toBeTruthy()
-    })
-    it('Test that people with only ROLE_ADJUSTMENTS_MAINTAINER are valid', async () => {
-      const hasAccess = userPermissionsService.hasAccessToAdjustments(['ROLE_ADJUSTMENTS_MAINTAINER'])
-      expect(hasAccess).toBeTruthy()
-    })
-    it('Test that people with only ROLE_RELEASE_DATES_CALCULATOR are not valid', async () => {
-      const hasAccess = userPermissionsService.hasAccessToAdjustments(['ROLE_RELEASE_DATES_CALCULATOR'])
-      expect(hasAccess).toBeFalsy()
-    })
-    it('Test that people with no roles are not valid', async () => {
-      const hasAccess = userPermissionsService.hasAccessToAdjustments([])
-      expect(hasAccess).toBeFalsy()
-    })
-  })
 })

--- a/server/services/userPermissionsService.ts
+++ b/server/services/userPermissionsService.ts
@@ -19,8 +19,4 @@ export default class UserPermissionsService {
   public allowSpecialSupport(roles: string[]): boolean {
     return roles.includes(AuthorisedRoles.ROLE_CRDS_SPECIALIST_SUPPORT)
   }
-
-  public hasAccessToAdjustments(roles: string[]): boolean {
-    return roles.includes('ROLE_ADJUSTMENTS_MAINTAINER')
-  }
 }

--- a/server/services/userPermissionsService.ts
+++ b/server/services/userPermissionsService.ts
@@ -19,4 +19,8 @@ export default class UserPermissionsService {
   public allowSpecialSupport(roles: string[]): boolean {
     return roles.includes(AuthorisedRoles.ROLE_CRDS_SPECIALIST_SUPPORT)
   }
+
+  public hasAccessToAdjustments(roles: string[]): boolean {
+    return roles.includes('ROLE_ADJUSTMENTS_MAINTAINER')
+  }
 }

--- a/server/views/pages/ccardIndex.njk
+++ b/server/views/pages/ccardIndex.njk
@@ -11,9 +11,7 @@
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-xl" data-qa="main-heading" id="main-heading">
-                Calculations and release dates
-            </h1>
+            <h1 class="govuk-heading-xl" data-qa="main-heading" id="main-heading">Calculations and release dates</h1>
         </div>
     </div>
 {% endblock %}

--- a/server/views/pages/ccardIndex.njk
+++ b/server/views/pages/ccardIndex.njk
@@ -1,0 +1,19 @@
+{% extends "../partials/layout.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set pageTitle = applicationName + " - Home" %}
+{% set pageId = "index" %}
+
+{% block aside %}
+    {% include "../../views/pages/partials/prisonerIdentityBar.njk" %}
+{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl" data-qa="main-heading" id="main-heading">
+                Calculations and release dates
+            </h1>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
Added a feature toggle for CCARD layout changes and route to the new landing page if going to /?prisonId=XXXXXX, formerly known as DPS landing page, and the feature toggle is on. Turned on in dev along with DPS header