### PR TITLE
CRS-1826: Hide subnav and blue bar if CRD only user

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -22,6 +22,7 @@ import AuthorisedRoles from './enumerations/authorisedRoles'
 
 import routes from './routes'
 import type { Services } from './services'
+import setUpCCARDComponents from './middleware/setUpCCARDComponents'
 
 export default function createApp(services: Services): express.Application {
   const app = express()
@@ -43,6 +44,7 @@ export default function createApp(services: Services): express.Application {
   app.use(setUpCsrf())
   app.use(setUpCurrentUser(services))
   app.use(setUpFrontendComponents(services))
+  app.use(setUpCCARDComponents())
   app.use(routes(services))
 
   app.use((req, res, next) => next(createError(404, 'Not found')))

--- a/server/middleware/setUpCCARDComponents.test.ts
+++ b/server/middleware/setUpCCARDComponents.test.ts
@@ -1,0 +1,47 @@
+import type { Request, Response } from 'express'
+
+import setUpCCARDComponents from './setUpCCARDComponents'
+
+describe('setUpCCARDComponents', () => {
+  let req: Request
+  const next = jest.fn()
+
+  function createResWithToken({ roles }: { roles: string[] }): Response {
+    return {
+      locals: {
+        user: {
+          userRoles: roles,
+        },
+      },
+      redirect: jest.fn(),
+    } as unknown as Response
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should set showCCARDNav to false if user has access no relevant roles', () => {
+    const res = createResWithToken({ roles: [] })
+
+    setUpCCARDComponents()(req, res, next)
+    expect(res.locals.showCCARDNav).toBeFalsy()
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should set showCCARDNav to false if user has access to CRD only', () => {
+    const res = createResWithToken({ roles: ['ROLE_RELEASE_DATES_CALCULATOR'] })
+
+    setUpCCARDComponents()(req, res, next)
+    expect(res.locals.showCCARDNav).toBeFalsy()
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should set showCCARDNav to true if user has access to CRD and adjustments', () => {
+    const res = createResWithToken({ roles: ['ROLE_RELEASE_DATES_CALCULATOR', 'ROLE_ADJUSTMENTS_MAINTAINER'] })
+
+    setUpCCARDComponents()(req, res, next)
+    expect(res.locals.showCCARDNav).toBeTruthy()
+    expect(next).toHaveBeenCalled()
+  })
+})

--- a/server/middleware/setUpCCARDComponents.ts
+++ b/server/middleware/setUpCCARDComponents.ts
@@ -1,0 +1,11 @@
+import { RequestHandler } from 'express'
+import AuthorisedRoles from '../enumerations/authorisedRoles'
+
+export default function setUpCCARDComponents(): RequestHandler {
+  return async (req, res, next) => {
+    const roles = res.locals.user.userRoles
+    res.locals.showCCARDNav =
+      roles.includes(AuthorisedRoles.ROLE_RELEASE_DATES_CALCULATOR) && roles.includes('ROLE_ADJUSTMENTS_MAINTAINER')
+    next()
+  }
+}

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -9,6 +9,7 @@ import * as auth from '../../authentication/auth'
 import type { Services } from '../../services'
 import type { ApplicationInfo } from '../../applicationInfo'
 import SessionSetup from './sessionSetup'
+import setUpCCARDComponents from '../../middleware/setUpCCARDComponents'
 
 const testAppInfo: ApplicationInfo = {
   applicationName: 'test',
@@ -56,6 +57,7 @@ function appSetup(
   })
   app.use(express.json())
   app.use(express.urlencoded({ extended: true }))
+  app.use(setUpCCARDComponents())
   app.use(routes(services))
   app.use((req, res, next) => next(new NotFound()))
   app.use(errorHandler(production))

--- a/server/views/pages/ccardIndex.njk
+++ b/server/views/pages/ccardIndex.njk
@@ -11,7 +11,9 @@
 } %}
 {% block beforeContent %}
     {{super()}}
-    {{ subNavigation(commonElementConfig.environment, navigation, commonElementConfig.prisonNumber) }}
+    {% if showCCARDNav %}
+        {{ subNavigation(commonElementConfig.environment, navigation, commonElementConfig.prisonNumber) }}
+    {% endif %}
 {% endblock %}
 {% block content %}
     <div class="govuk-grid-row">

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -78,7 +78,7 @@
     {% include "./header.njk" %}
   {% endif %}
 
-  {% if featureToggles.useCCARDLayout %}
+  {% if featureToggles.useCCARDLayout and showCCARDNav %}
       {{ serviceHeader(commonElementConfig.serviceHeader) }}
   {% endif %}
 


### PR DESCRIPTION
If the user is CRD only and doesn't have access to adjustments then we hide the blue service banner and sub nav on the DPS landing page.