### PR TITLE
CRS-1859 Use legacy slack channels for alerting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,11 @@ orbs:
 parameters:
   alerts-slack-channel:
     type: string
-    default: farsight-alerts
+    default: legacy-replacement-alerts-non-prod
 
   releases-slack-channel:
     type: string
-    default: dps-releases
+    default: legacy-replacement-releases
 
   node-version:
     type: string

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -40,4 +40,4 @@ generic-service:
   allowlist: null
 
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service-dev
+  alertSeverity: legacy-replacement-alerts-non-prod

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -37,4 +37,4 @@ generic-service:
     ENVIRONMENT_NAME: PRE-PRODUCTION
 
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service-dev
+  alertSeverity: legacy-replacement-alerts-non-prod

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -29,4 +29,4 @@ generic-service:
     ERS2024_BANNER_ENABLED: "true"
     USE_CCARD_LAYOUT: "false"
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service-dev
+  alertSeverity: legacy-replacement-alerts


### PR DESCRIPTION
* Update slack channels used for alerts and notification to be the new legacy specific ones