### PR TITLE
CRS-1847: use backend for date descriptions

### DIFF
--- a/integration_tests/e2e/approvedDatesPath.cy.ts
+++ b/integration_tests/e2e/approvedDatesPath.cy.ts
@@ -1,0 +1,235 @@
+import AlternativeReleaseIntroPage from '../pages/alternativeReleaseIntro'
+import CalculationCompletePage from '../pages/calculationComplete'
+import CalculationSummaryPage from '../pages/calculationSummary'
+import CheckInformationPage from '../pages/checkInformation'
+import Page from '../pages/page'
+import SelectOffencesPage from '../pages/selectOffences'
+import ApprovedDatesQuestionPage from '../pages/approvedDatesQuestion'
+import CalculationReasonPage from '../pages/reasonForCalculation'
+import CCARDLandingPage from '../pages/CCARDLandingPage'
+import ApprovedDatesSelectDatesToEnterPage from '../pages/approvedDatesSelectDatesToEnter'
+import ApprovedDatesEnterDatePage from '../pages/approvedDatesEnterDate'
+import ApprovedDatesRemoveDatePage from '../pages/approvedDatesRemoveDate'
+
+context('End to end user journeys entering and modifying approved dates', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubManageUser')
+    cy.task('stubPrisonerSearch')
+    cy.task('stubGetUserCaseloads')
+    cy.task('stubGetPrisonerDetails')
+    cy.task('stubGetSentencesAndOffences')
+    cy.task('stubGetAnalyzedSentencesAndOffences')
+    cy.task('stubCalculatePreliminaryReleaseDates')
+    cy.task('stubGetCalculationResults')
+    cy.task('stubGetCalculationBreakdown')
+    cy.task('stubConfirmCalculation')
+    cy.task('stubGetNextWorkingDay')
+    cy.task('stubGetPreviousWorkingDay')
+    cy.task('stubValidate')
+    cy.task('stubAdjustments')
+    cy.task('stubGetAnalyzedSentenceAdjustments')
+    cy.task('stubSentencesAndOffences')
+    cy.task('stubPrisonerDetails')
+    cy.task('stubLatestCalculation')
+    cy.task('stubCalculationQuestions')
+    cy.task('stubCalculationUserInputs')
+    cy.task('stubSupportedValidation')
+    cy.task('stubGetGenuineOverride')
+    cy.task('stubGetActiveCalculationReasons')
+    cy.task('stubGetCalculationHistory')
+    cy.task('stubGetDetailedCalculationResults')
+    cy.task('stubComponents')
+    cy.task('stubGetLatestCalculation')
+    cy.task('stubGetReferenceDates')
+  })
+
+  it('Can add all dates', () => {
+    cy.signIn()
+    const landingPage = CCARDLandingPage.goTo('A1234AB')
+    landingPage.calculateReleaseDatesAction().click()
+
+    const calculationReasonPage = CalculationReasonPage.verifyOnPage(CalculationReasonPage)
+    calculationReasonPage.radioByIndex(1).check()
+    calculationReasonPage.submitReason().click()
+
+    const alternativeReleaseIntro = AlternativeReleaseIntroPage.verifyOnPage(AlternativeReleaseIntroPage)
+    alternativeReleaseIntro.continueButton().click()
+
+    const listAPage = SelectOffencesPage.verifyOnPage<SelectOffencesPage>(SelectOffencesPage, 'list-a')
+    listAPage.checkboxByIndex(0).click()
+    listAPage.continueButton().click()
+    const listCPage = SelectOffencesPage.verifyOnPage<SelectOffencesPage>(SelectOffencesPage, 'list-c')
+    listCPage.noneSelectedCheckbox().click()
+    listCPage.continueButton().click()
+    const checkInformationPage = Page.verifyOnPage(CheckInformationPage)
+    checkInformationPage.calculateButton().click()
+
+    const calculationSummaryPage = Page.verifyOnPage(CalculationSummaryPage)
+    calculationSummaryPage.submitToNomisButton().click()
+
+    const approvedDatesQuestionPage = Page.verifyOnPage(ApprovedDatesQuestionPage)
+    approvedDatesQuestionPage.yes().click()
+    approvedDatesQuestionPage.continue().click()
+
+    const selectApprovedDatesTypesPage = Page.verifyOnPage(ApprovedDatesSelectDatesToEnterPage)
+    selectApprovedDatesTypesPage.expectDateOffered(['APD', 'HDCAD', 'ROTL'])
+    selectApprovedDatesTypesPage.checkDate('APD')
+    selectApprovedDatesTypesPage.checkDate('HDCAD')
+    selectApprovedDatesTypesPage.checkDate('ROTL')
+    selectApprovedDatesTypesPage.continue().click()
+
+    const enterApdPage = Page.verifyOnPage(ApprovedDatesEnterDatePage)
+    enterApdPage.checkIsFor('APD (Approved parole date)')
+    enterApdPage.enterDate('APD', '01', '06', '2026')
+    enterApdPage.continue().click()
+
+    const enterHdcadPage = Page.verifyOnPage(ApprovedDatesEnterDatePage)
+    enterHdcadPage.checkIsFor('HDCAD (Home detention curfew approved date)')
+    enterHdcadPage.enterDate('HDCAD', '20', '11', '2027')
+    enterHdcadPage.continue().click()
+
+    const enterRotlPage = Page.verifyOnPage(ApprovedDatesEnterDatePage)
+    enterRotlPage.checkIsFor('ROTL (Release on temporary licence)')
+    enterRotlPage.enterDate('ROTL', '30', '12', '2028')
+    enterRotlPage.continue().click()
+
+    const calculationSummaryPageAfterApprovedDates = Page.verifyOnPage(CalculationSummaryPage)
+    calculationSummaryPageAfterApprovedDates.dateShouldHaveValue('APD', 'Monday, 01 June 2026')
+    calculationSummaryPageAfterApprovedDates.dateShouldHaveValue('HDCAD', 'Saturday, 20 November 2027')
+    calculationSummaryPageAfterApprovedDates.dateShouldHaveValue('ROTL', 'Saturday, 30 December 2028')
+    calculationSummaryPageAfterApprovedDates.submitToNomisButton().click()
+
+    const calculationCompletePage = Page.verifyOnPage(CalculationCompletePage)
+
+    calculationCompletePage
+      .title()
+      .should('contain.text', 'Release dates saved to NOMIS for')
+      .should('contain.text', 'Marvin Haggler')
+  })
+
+  it('Can edit a date', () => {
+    cy.signIn()
+    const landingPage = CCARDLandingPage.goTo('A1234AB')
+    landingPage.calculateReleaseDatesAction().click()
+
+    const calculationReasonPage = CalculationReasonPage.verifyOnPage(CalculationReasonPage)
+    calculationReasonPage.radioByIndex(1).check()
+    calculationReasonPage.submitReason().click()
+
+    const alternativeReleaseIntro = AlternativeReleaseIntroPage.verifyOnPage(AlternativeReleaseIntroPage)
+    alternativeReleaseIntro.continueButton().click()
+
+    const listAPage = SelectOffencesPage.verifyOnPage<SelectOffencesPage>(SelectOffencesPage, 'list-a')
+    listAPage.checkboxByIndex(0).click()
+    listAPage.continueButton().click()
+    const listCPage = SelectOffencesPage.verifyOnPage<SelectOffencesPage>(SelectOffencesPage, 'list-c')
+    listCPage.noneSelectedCheckbox().click()
+    listCPage.continueButton().click()
+    const checkInformationPage = Page.verifyOnPage(CheckInformationPage)
+    checkInformationPage.calculateButton().click()
+
+    const calculationSummaryPage = Page.verifyOnPage(CalculationSummaryPage)
+    calculationSummaryPage.submitToNomisButton().click()
+
+    const approvedDatesQuestionPage = Page.verifyOnPage(ApprovedDatesQuestionPage)
+    approvedDatesQuestionPage.yes().click()
+    approvedDatesQuestionPage.continue().click()
+
+    const selectApprovedDatesTypesPage = Page.verifyOnPage(ApprovedDatesSelectDatesToEnterPage)
+    selectApprovedDatesTypesPage.expectDateOffered(['APD', 'HDCAD', 'ROTL'])
+    selectApprovedDatesTypesPage.checkDate('APD')
+    selectApprovedDatesTypesPage.continue().click()
+
+    const enterApdPage = Page.verifyOnPage(ApprovedDatesEnterDatePage)
+    enterApdPage.checkIsFor('APD (Approved parole date)')
+    enterApdPage.enterDate('APD', '01', '06', '2026')
+    enterApdPage.continue().click()
+
+    const calculationSummaryPageAfterApprovedDates = Page.verifyOnPage(CalculationSummaryPage)
+    calculationSummaryPageAfterApprovedDates.dateShouldHaveValue('APD', 'Monday, 01 June 2026')
+    calculationSummaryPageAfterApprovedDates.changeDateLink('APD').click()
+
+    const editApdPage = Page.verifyOnPage(ApprovedDatesEnterDatePage)
+    editApdPage.checkIsFor('APD (Approved parole date)')
+    editApdPage.clearDate('APD')
+    editApdPage.enterDate('APD', '01', '06', '2027')
+    editApdPage.continue().click()
+
+    const calculationSummaryPageAfterEditApd = Page.verifyOnPage(CalculationSummaryPage)
+    calculationSummaryPageAfterEditApd.dateShouldHaveValue('APD', 'Tuesday, 01 June 2027')
+    calculationSummaryPageAfterEditApd.submitToNomisButton().click()
+
+    const calculationCompletePage = Page.verifyOnPage(CalculationCompletePage)
+    calculationCompletePage
+      .title()
+      .should('contain.text', 'Release dates saved to NOMIS for')
+      .should('contain.text', 'Marvin Haggler')
+  })
+
+  it('Can remove a date', () => {
+    cy.signIn()
+    const landingPage = CCARDLandingPage.goTo('A1234AB')
+    landingPage.calculateReleaseDatesAction().click()
+
+    const calculationReasonPage = CalculationReasonPage.verifyOnPage(CalculationReasonPage)
+    calculationReasonPage.radioByIndex(1).check()
+    calculationReasonPage.submitReason().click()
+
+    const alternativeReleaseIntro = AlternativeReleaseIntroPage.verifyOnPage(AlternativeReleaseIntroPage)
+    alternativeReleaseIntro.continueButton().click()
+
+    const listAPage = SelectOffencesPage.verifyOnPage<SelectOffencesPage>(SelectOffencesPage, 'list-a')
+    listAPage.checkboxByIndex(0).click()
+    listAPage.continueButton().click()
+    const listCPage = SelectOffencesPage.verifyOnPage<SelectOffencesPage>(SelectOffencesPage, 'list-c')
+    listCPage.noneSelectedCheckbox().click()
+    listCPage.continueButton().click()
+    const checkInformationPage = Page.verifyOnPage(CheckInformationPage)
+    checkInformationPage.calculateButton().click()
+
+    const calculationSummaryPage = Page.verifyOnPage(CalculationSummaryPage)
+    calculationSummaryPage.submitToNomisButton().click()
+
+    const approvedDatesQuestionPage = Page.verifyOnPage(ApprovedDatesQuestionPage)
+    approvedDatesQuestionPage.yes().click()
+    approvedDatesQuestionPage.continue().click()
+
+    const selectApprovedDatesTypesPage = Page.verifyOnPage(ApprovedDatesSelectDatesToEnterPage)
+    selectApprovedDatesTypesPage.expectDateOffered(['APD', 'HDCAD', 'ROTL'])
+    selectApprovedDatesTypesPage.checkDate('APD')
+    selectApprovedDatesTypesPage.checkDate('HDCAD')
+    selectApprovedDatesTypesPage.continue().click()
+
+    const enterApdPage = Page.verifyOnPage(ApprovedDatesEnterDatePage)
+    enterApdPage.checkIsFor('APD (Approved parole date)')
+    enterApdPage.enterDate('APD', '01', '06', '2026')
+    enterApdPage.continue().click()
+
+    const enterHdcadPage = Page.verifyOnPage(ApprovedDatesEnterDatePage)
+    enterHdcadPage.checkIsFor('HDCAD (Home detention curfew approved date)')
+    enterHdcadPage.enterDate('HDCAD', '20', '11', '2027')
+    enterHdcadPage.continue().click()
+
+    const calculationSummaryPageAfterApprovedDates = Page.verifyOnPage(CalculationSummaryPage)
+    calculationSummaryPageAfterApprovedDates.dateShouldHaveValue('APD', 'Monday, 01 June 2026')
+    calculationSummaryPageAfterApprovedDates.dateShouldHaveValue('HDCAD', 'Saturday, 20 November 2027')
+    calculationSummaryPageAfterApprovedDates.removeDateLink('APD').click()
+
+    const removeApdPage = Page.verifyOnPage(ApprovedDatesRemoveDatePage)
+    removeApdPage.yes().click()
+    removeApdPage.continue().click()
+
+    const calculationSummaryPageAfterRemoveApd = Page.verifyOnPage(CalculationSummaryPage)
+    calculationSummaryPageAfterRemoveApd.dateShouldNotBePresent('APD')
+    calculationSummaryPageAfterRemoveApd.dateShouldHaveValue('HDCAD', 'Saturday, 20 November 2027')
+    calculationSummaryPageAfterRemoveApd.submitToNomisButton().click()
+
+    const calculationCompletePage = Page.verifyOnPage(CalculationCompletePage)
+    calculationCompletePage
+      .title()
+      .should('contain.text', 'Release dates saved to NOMIS for')
+      .should('contain.text', 'Marvin Haggler')
+  })
+})

--- a/integration_tests/mockApis/calculateReleaseDatesApi.ts
+++ b/integration_tests/mockApis/calculateReleaseDatesApi.ts
@@ -1064,4 +1064,42 @@ export default {
       },
     })
   },
+  stubGetReferenceDates: (): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/calculate-release-dates/reference-data/date-type`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: [
+          { type: 'CRD', description: 'Conditional release date' },
+          { type: 'LED', description: 'Licence expiry date' },
+          { type: 'SED', description: 'Sentence expiry date' },
+          { type: 'NPD', description: 'Non-parole date' },
+          { type: 'ARD', description: 'Automatic release date' },
+          { type: 'TUSED', description: 'Top up supervision expiry date' },
+          { type: 'PED', description: 'Parole eligibility date' },
+          { type: 'SLED', description: 'Sentence and licence expiry date' },
+          { type: 'HDCED', description: 'Home detention curfew eligibility date' },
+          { type: 'NCRD', description: 'Notional conditional release date' },
+          { type: 'ETD', description: 'Early transfer date' },
+          { type: 'MTD', description: 'Mid transfer date' },
+          { type: 'LTD', description: 'Late transfer date' },
+          { type: 'DPRRD', description: 'Detention and training order post recall release date' },
+          { type: 'PRRD', description: 'Post recall release date' },
+          { type: 'ESED', description: 'Effective sentence end date' },
+          { type: 'ERSED', description: 'Early removal scheme eligibility date' },
+          { type: 'TERSED', description: 'Tariff-expired removal scheme eligibility date' },
+          { type: 'APD', description: 'Approved parole date' },
+          { type: 'HDCAD', description: 'Home detention curfew approved date' },
+          { type: 'None', description: 'None of the above dates apply' },
+          { type: 'Tariff', description: 'known as the Tariff expiry date' },
+          { type: 'ROTL', description: 'Release on temporary licence' },
+          { type: 'HDCED4PLUS', description: 'HDCED4+' },
+        ],
+      },
+    })
+  },
 }

--- a/integration_tests/pages/approvedDatesEnterDate.ts
+++ b/integration_tests/pages/approvedDatesEnterDate.ts
@@ -1,0 +1,28 @@
+import Page, { PageElement } from './page'
+
+export default class ApprovedDatesEnterDatePage extends Page {
+  constructor() {
+    super('enter-approved-date')
+  }
+
+  public checkIsFor(fullDateString: string) {
+    const expected = `Enter the ${fullDateString}`
+    cy.get('.govuk-fieldset__heading').should('contain.text', expected)
+  }
+
+  public enterDate(type: string, day: string, month: string, year: string) {
+    cy.get(`#${type}-day`).type(day)
+    cy.get(`#${type}-month`).type(month)
+    cy.get(`#${type}-year`).type(year)
+  }
+
+  public clearDate(type: string) {
+    cy.get(`#${type}-day`).clear()
+    cy.get(`#${type}-month`).clear()
+    cy.get(`#${type}-year`).clear()
+  }
+
+  public continue(): PageElement {
+    return cy.get('[data-qa=date-entry]')
+  }
+}

--- a/integration_tests/pages/approvedDatesQuestion.ts
+++ b/integration_tests/pages/approvedDatesQuestion.ts
@@ -14,6 +14,10 @@ export default class ApprovedDatesQuestionPage extends Page {
     return cy.get('#approvedDatesQuestion-2')
   }
 
+  public yes(): PageElement {
+    return cy.get('#approvedDatesQuestion')
+  }
+
   public continue(): PageElement {
     return cy.get('[data-qa=approved-dates-question]')
   }

--- a/integration_tests/pages/approvedDatesRemoveDate.ts
+++ b/integration_tests/pages/approvedDatesRemoveDate.ts
@@ -1,0 +1,15 @@
+import Page, { PageElement } from './page'
+
+export default class ApprovedDatesRemoveDatePage extends Page {
+  constructor() {
+    super('remove-approved-date')
+  }
+
+  public yes(): PageElement {
+    return cy.get('#remove-date')
+  }
+
+  public continue(): PageElement {
+    return cy.get('[data-qa=remove-date]')
+  }
+}

--- a/integration_tests/pages/approvedDatesSelectDatesToEnter.ts
+++ b/integration_tests/pages/approvedDatesSelectDatesToEnter.ts
@@ -1,0 +1,27 @@
+import Page, { PageElement } from './page'
+
+export default class ApprovedDatesSelectDatesToEnterPage extends Page {
+  constructor() {
+    super('select-approved-date-types')
+  }
+
+  public expectDateOffered(expected: string[]) {
+    cy.get('.govuk-checkboxes__input')
+      .then($els => Cypress._.map($els, 'value'))
+      .should('deep.equal', expected)
+  }
+
+  public continue(): PageElement {
+    return cy.get('[data-qa=manual-entry]')
+  }
+
+  public checkDate(type: string) {
+    cy.get('.govuk-checkboxes__input').then($els =>
+      Cypress._.each($els, e => {
+        if (e.getAttribute('value') === type) {
+          e.click()
+        }
+      }),
+    )
+  }
+}

--- a/integration_tests/pages/calculationSummary.ts
+++ b/integration_tests/pages/calculationSummary.ts
@@ -21,5 +21,21 @@ export default class CalculationSummaryPage extends CalculationSummaryCommon {
     })
   }
 
+  public dateShouldHaveValue(type: string, expected: string) {
+    cy.get(`[data-qa=${type}-date]`).should('contain.text', expected)
+  }
+
+  public dateShouldNotBePresent(type: string) {
+    cy.get(`[data-qa=${type}-date]`).should('not.exist')
+  }
+
+  public changeDateLink(type: string): PageElement {
+    return cy.get(`[data-qa=change-approved-${type}-link]`)
+  }
+
+  public removeDateLink(type: string): PageElement {
+    return cy.get(`[data-qa=remove-approved-${type}-link]`)
+  }
+
   public submitToNomisButton = (): PageElement => cy.get('[data-qa=submit-to-nomis]')
 }

--- a/server/@types/calculateReleaseDates/calculateReleaseDatesClientTypes.ts
+++ b/server/@types/calculateReleaseDates/calculateReleaseDatesClientTypes.ts
@@ -38,3 +38,4 @@ export type DetailedCalculationResults = components['schemas']['DetailedCalculat
 export type DetailedDate = components['schemas']['DetailedDate']
 export type CalculationPrisonerDetails = components['schemas']['PrisonerDetails']
 export type LatestCalculation = components['schemas']['LatestCalculation']
+export type DateTypeDefinition = components['schemas']['DateTypeDefinition']

--- a/server/api/calculateReleaseDatesApiClient.test.ts
+++ b/server/api/calculateReleaseDatesApiClient.test.ts
@@ -64,5 +64,17 @@ describe('Calculate release dates API client tests', () => {
         await expect(client.getLatestCalculationForPrisoner(prisonerId)).rejects.toThrow('Not Found')
       })
     })
+    describe('Get reference data', () => {
+      it('Get date types and descriptions', async () => {
+        const dates = [
+          { type: 'FOO', description: 'Foo date' },
+          { type: 'BAR', description: 'Bar date' },
+        ]
+        fakeApi.get('/reference-data/date-type', '').reply(200, dates)
+        const data = await new CalculateReleaseDatesApiClient(token).getDateTypeDefinitions()
+        expect(data).toEqual(dates)
+        expect(nock.isDone()).toBe(true)
+      })
+    })
   })
 })

--- a/server/api/calculateReleaseDatesApiClient.ts
+++ b/server/api/calculateReleaseDatesApiClient.ts
@@ -24,6 +24,7 @@ import {
   HistoricCalculation,
   DetailedCalculationResults,
   LatestCalculation,
+  DateTypeDefinition,
 } from '../@types/calculateReleaseDates/calculateReleaseDatesClientTypes'
 import {
   AnalyzedPrisonApiBookingAndSentenceAdjustments,
@@ -309,5 +310,11 @@ export default class CalculateReleaseDatesApiClient {
     return this.restClient.get({
       path: `/calculation/${prisonerId}/latest`,
     }) as Promise<LatestCalculation>
+  }
+
+  async getDateTypeDefinitions() {
+    return this.restClient.get({
+      path: '/reference-data/date-type',
+    }) as Promise<DateTypeDefinition[]>
   }
 }

--- a/server/routes/approvedDatesRoutes.ts
+++ b/server/routes/approvedDatesRoutes.ts
@@ -50,7 +50,7 @@ export default class ApprovedDatesRoutes {
     )
   }
 
-  public selectedApprovedDateTypes: RequestHandler = async (req, res): Promise<void> => {
+  public selectApprovedDateTypes: RequestHandler = async (req, res): Promise<void> => {
     const { caseloads, token } = res.locals.user
     const { nomsId, calculationRequestId } = req.params
     if (!req.session.selectedApprovedDates) {
@@ -60,7 +60,7 @@ export default class ApprovedDatesRoutes {
       req.session.selectedApprovedDates[nomsId] = []
     }
     const prisonerDetail = await this.prisonerService.getPrisonerDetail(nomsId, caseloads, token)
-    const config = this.approvedDatesService.getConfig(req)
+    const config = await this.approvedDatesService.getConfig(token, req)
     return res.render(
       'pages/approvedDates/selectApprovedDates',
       new SelectApprovedDatesViewModel(prisonerDetail, calculationRequestId, config),
@@ -77,7 +77,7 @@ export default class ApprovedDatesRoutes {
       req.session.selectedApprovedDates[nomsId] = []
     }
     const prisonerDetail = await this.prisonerService.getPrisonerDetail(nomsId, caseloads, token)
-    const { error, config } = this.approvedDatesService.submitApprovedDateTypes(req)
+    const { error, config } = await this.approvedDatesService.submitApprovedDateTypes(token, req)
     if (error) {
       return res.render(
         'pages/approvedDates/selectApprovedDates',
@@ -156,8 +156,9 @@ export default class ApprovedDatesRoutes {
   }
 
   public loadChangeDate: RequestHandler = async (req, res): Promise<void> => {
+    const { token } = res.locals.user
     const { nomsId, calculationRequestId } = req.params
-    const { date } = this.approvedDatesService.changeDate(req, nomsId)
+    const { date } = await this.approvedDatesService.changeDate(token, req, nomsId)
     return res.redirect(
       `/calculation/${nomsId}/${calculationRequestId}/submit-dates?year=${date.year}&month=${date.month}&day=${date.day}`,
     )
@@ -169,7 +170,7 @@ export default class ApprovedDatesRoutes {
     const prisonerDetail = await this.prisonerService.getPrisonerDetail(nomsId, caseloads, token)
     const dateToRemove: string = <string>req.query.dateType
     if (this.approvedDatesService.hasApprovedDateToRemove(req, nomsId, dateToRemove)) {
-      const fullDateName = this.manualEntryService.fullStringLookup(dateToRemove)
+      const fullDateName = await this.manualEntryService.fullStringLookup(token, dateToRemove)
       return res.render(
         'pages/approvedDates/removeDate',
         new RemoveApprovedDateViewModel(prisonerDetail, dateToRemove, fullDateName),
@@ -183,7 +184,7 @@ export default class ApprovedDatesRoutes {
     const { nomsId, calculationRequestId } = req.params
     const dateToRemove: string = <string>req.query.dateType
     const prisonerDetail = await this.prisonerService.getPrisonerDetail(nomsId, caseloads, token)
-    const fullDateName = this.manualEntryService.fullStringLookup(dateToRemove)
+    const fullDateName = await this.manualEntryService.fullStringLookup(token, dateToRemove)
     if (req.body['remove-date'] !== 'yes' && req.body['remove-date'] !== 'no') {
       return res.render(
         'pages/approvedDates/removeDate',

--- a/server/routes/genuineOverrideRoutes.test.ts
+++ b/server/routes/genuineOverrideRoutes.test.ts
@@ -679,7 +679,7 @@ describe('Genuine overrides routes tests', () => {
     userPermissionsService.allowSpecialSupport.mockReturnValue(true)
     calculateReleaseDatesService.getCalculationResultsByReference.mockResolvedValue(stubbedCalculationResults)
     prisonerService.getPrisonerDetail.mockResolvedValue(stubbedPrisonerData)
-    manualEntryService.getConfirmationConfiguration.mockReturnValue([])
+    manualEntryService.getConfirmationConfiguration.mockResolvedValue([])
     return request(app)
       .get('/specialist-support/calculation/ABC/confirm-override')
       .expect(200)
@@ -754,7 +754,7 @@ describe('Genuine overrides routes tests', () => {
     userPermissionsService.allowSpecialSupport.mockReturnValue(true)
     calculateReleaseDatesService.getCalculationResultsByReference.mockResolvedValue(stubbedCalculationResults)
     prisonerService.getPrisonerDetail.mockResolvedValue(stubbedPrisonerData)
-    manualEntryService.verifySelectedDateType.mockReturnValue({
+    manualEntryService.verifySelectedDateType.mockResolvedValue({
       error: false,
       config: undefined,
     })
@@ -770,7 +770,7 @@ describe('Genuine overrides routes tests', () => {
     userPermissionsService.allowSpecialSupport.mockReturnValue(true)
     calculateReleaseDatesService.getCalculationResultsByReference.mockResolvedValue(stubbedCalculationResults)
     prisonerService.getPrisonerDetail.mockResolvedValue(stubbedPrisonerData)
-    manualEntryService.verifySelectedDateType.mockReturnValue({
+    manualEntryService.verifySelectedDateType.mockResolvedValue({
       error: true,
       config: undefined,
     })

--- a/server/routes/genuineOverrideRoutes.ts
+++ b/server/routes/genuineOverrideRoutes.ts
@@ -419,7 +419,13 @@ export default class GenuineOverrideRoutes {
         token,
       )
       const prisonerDetail = await this.prisonerService.getPrisonerDetail(releaseDates.prisonerId, caseloads, token)
-      const { config } = this.manualEntryService.verifySelectedDateType(req, releaseDates.prisonerId, false, true)
+      const { config } = await this.manualEntryService.verifySelectedDateType(
+        token,
+        req,
+        releaseDates.prisonerId,
+        false,
+        true,
+      )
       return res.render(
         'pages/genuineOverrides/dateTypeSelection',
         new GenuineOverridesDateTypeSelectionViewModel(prisonerDetail, config, calculationReference),
@@ -442,7 +448,8 @@ export default class GenuineOverrideRoutes {
       )
       const prisonerDetail = await this.prisonerService.getPrisonerDetail(releaseDates.prisonerId, caseloads, token)
 
-      const { error, config } = this.manualEntryService.verifySelectedDateType(
+      const { error, config } = await this.manualEntryService.verifySelectedDateType(
+        token,
         req,
         releaseDates.prisonerId,
         false,
@@ -454,7 +461,7 @@ export default class GenuineOverrideRoutes {
           new GenuineOverridesDateTypeSelectionViewModel(prisonerDetail, config, calculationReference, true),
         )
       }
-      this.manualEntryService.addManuallyCalculatedDateTypes(req, releaseDates.prisonerId)
+      await this.manualEntryService.addManuallyCalculatedDateTypes(token, req, releaseDates.prisonerId)
 
       return res.redirect(`/specialist-support/calculation/${calculationReference}/enter-date`)
     }
@@ -540,7 +547,7 @@ export default class GenuineOverrideRoutes {
         token,
       )
       const prisonerDetail = await this.prisonerService.getPrisonerDetail(releaseDates.prisonerId, caseloads, token)
-      const rows = this.manualEntryService.getConfirmationConfiguration(req, releaseDates.prisonerId, true)
+      const rows = await this.manualEntryService.getConfirmationConfiguration(token, req, releaseDates.prisonerId, true)
 
       return res.render(
         'pages/genuineOverrides/confirmOverride',
@@ -558,7 +565,7 @@ export default class GenuineOverrideRoutes {
         calculationReference,
         token,
       )
-      const { date } = this.manualEntryService.changeDate(req, releaseDates.prisonerId)
+      const { date } = await this.manualEntryService.changeDate(token, req, releaseDates.prisonerId)
       return res.redirect(
         `/specialist-support/calculation/${calculationReference}/enter-date?year=${date.year}&month=${date.month}&day=${date.day}`,
       )
@@ -581,7 +588,7 @@ export default class GenuineOverrideRoutes {
           (d: ManualEntrySelectedDate) => d.dateType === dateToRemove,
         )
       ) {
-        const fullDateName = this.manualEntryService.fullStringLookup(dateToRemove)
+        const fullDateName = await this.manualEntryService.fullStringLookup(token, dateToRemove)
         return res.render(
           'pages/genuineOverrides/removeDate',
           new GenuineOverridesRemoveDateViewModel(prisonerDetail, dateToRemove, fullDateName, calculationReference),
@@ -603,7 +610,7 @@ export default class GenuineOverrideRoutes {
         token,
       )
       const prisonerDetail = await this.prisonerService.getPrisonerDetail(releaseDates.prisonerId, caseloads, token)
-      const fullDateName = this.manualEntryService.fullStringLookup(dateToRemove)
+      const fullDateName = await this.manualEntryService.fullStringLookup(token, dateToRemove)
       if (req.body['remove-date'] !== 'yes' && req.body['remove-date'] !== 'no') {
         const error = true
         return res.render(

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -123,7 +123,7 @@ export default function Index({
     get('/calculation/:nomsId/:calculationRequestId/store', calculationAccessRoutes.submitCalculationSummary)
     get(
       '/calculation/:nomsId/:calculationRequestId/select-approved-dates',
-      approvedDatesAccessRoutes.selectedApprovedDateTypes,
+      approvedDatesAccessRoutes.selectApprovedDateTypes,
     )
     post(
       '/calculation/:nomsId/:calculationRequestId/select-approved-dates',

--- a/server/routes/manualEntryRoutes.ts
+++ b/server/routes/manualEntryRoutes.ts
@@ -67,7 +67,8 @@ export default class ManualEntryRoutes {
       token,
     )
 
-    const { error, config } = this.manualEntryService.verifySelectedDateType(
+    const { error, config } = await this.manualEntryService.verifySelectedDateType(
+      token,
       req,
       nomsId,
       hasIndeterminateSentences,
@@ -80,7 +81,7 @@ export default class ManualEntryRoutes {
         new ManualEntrySelectDatesViewModel(prisonerDetail, config, insufficientDatesSelected),
       )
     }
-    this.manualEntryService.addManuallyCalculatedDateTypes(req, nomsId)
+    await this.manualEntryService.addManuallyCalculatedDateTypes(token, req, nomsId)
     return res.redirect(`/calculation/${nomsId}/manual-entry/enter-date`)
   }
 
@@ -101,7 +102,13 @@ export default class ManualEntryRoutes {
       token,
     )
     const firstLoad = !req.query.addExtra
-    const { config } = this.manualEntryService.verifySelectedDateType(req, nomsId, hasIndeterminateSentences, firstLoad)
+    const { config } = await this.manualEntryService.verifySelectedDateType(
+      token,
+      req,
+      nomsId,
+      hasIndeterminateSentences,
+      firstLoad,
+    )
     return res.render(
       'pages/manualEntry/dateTypeSelection',
       new ManualEntrySelectDatesViewModel(prisonerDetail, config),
@@ -176,7 +183,7 @@ export default class ManualEntryRoutes {
     if (unsupportedSentenceOrCalculationMessages.length === 0) {
       return res.redirect(`/calculation/${nomsId}/check-information`)
     }
-    const rows = this.manualEntryService.getConfirmationConfiguration(req, nomsId)
+    const rows = await this.manualEntryService.getConfirmationConfiguration(token, req, nomsId)
     return res.render('pages/manualEntry/confirmation', new ManualEntryConfirmationViewModel(prisonerDetail, rows))
   }
 
@@ -193,7 +200,7 @@ export default class ManualEntryRoutes {
     if (
       req.session.selectedManualEntryDates[nomsId].some((d: ManualEntrySelectedDate) => d.dateType === dateToRemove)
     ) {
-      const fullDateName = this.manualEntryService.fullStringLookup(dateToRemove)
+      const fullDateName = await this.manualEntryService.fullStringLookup(token, dateToRemove)
       return res.render(
         'pages/manualEntry/removeDate',
         new ManualEntryRemoteDateViewModel(prisonerDetail, dateToRemove, fullDateName),
@@ -212,7 +219,7 @@ export default class ManualEntryRoutes {
     }
     const dateToRemove: string = <string>req.query.dateType
     const prisonerDetail = await this.prisonerService.getPrisonerDetail(nomsId, caseloads, token)
-    const fullDateName = this.manualEntryService.fullStringLookup(dateToRemove)
+    const fullDateName = await this.manualEntryService.fullStringLookup(token, dateToRemove)
     if (req.body['remove-date'] !== 'yes' && req.body['remove-date'] !== 'no') {
       return res.render(
         'pages/manualEntry/removeDate',
@@ -235,7 +242,7 @@ export default class ManualEntryRoutes {
       return res.redirect(`/calculation/${nomsId}/check-information`)
     }
 
-    const { date } = this.manualEntryService.changeDate(req, nomsId)
+    const { date } = await this.manualEntryService.changeDate(token, req, nomsId)
     return res.redirect(
       `/calculation/${nomsId}/manual-entry/enter-date?year=${date.year}&month=${date.month}&day=${date.day}`,
     )

--- a/server/services/dateTypeConfigurationService.test.ts
+++ b/server/services/dateTypeConfigurationService.test.ts
@@ -1,35 +1,85 @@
+import nock from 'nock'
 import DateTypeConfigurationService from './dateTypeConfigurationService'
 import { ManualEntrySelectedDate } from '../@types/calculateReleaseDates/calculateReleaseDatesClientTypes'
+import config from '../config'
 
 const dateTypeConfigurationService = new DateTypeConfigurationService()
 describe('dateTypeConfigurationService', () => {
-  it('returns the manual entry date with the date set if already in session', () => {
-    const configured = dateTypeConfigurationService.configure(
-      ['CRD'],
-      [
+  describe('loads date config from backend', () => {
+    let fakeApi: nock.Scope
+
+    beforeEach(() => {
+      config.apis.calculateReleaseDates.url = 'http://localhost:8100'
+      fakeApi = nock(config.apis.calculateReleaseDates.url)
+      const dates = [
+        { type: 'CRD', description: 'Conditional release date' },
+        { type: 'ARD', description: 'Automatic release date' },
+        { type: 'None', description: 'None of the above dates apply' },
+      ]
+      fakeApi.get('/reference-data/date-type', '').reply(200, dates)
+    })
+
+    afterEach(() => {
+      nock.cleanAll()
+    })
+
+    it('returns the manual entry date with the date set if already in session', async () => {
+      const configured = await dateTypeConfigurationService.configureViaBackend(
+        'token',
+        ['CRD', 'ARD'],
+        [
+          {
+            dateType: 'CRD',
+            dateText: 'CRD (Conditional release date)',
+            date: { day: 3, month: 3, year: 2017 },
+          } as ManualEntrySelectedDate,
+          {
+            dateType: 'ARD',
+            dateText: 'ARD (Automatic release date)',
+            date: { day: 4, month: 4, year: 2018 },
+          } as ManualEntrySelectedDate,
+        ],
+      )
+      expect(configured).toEqual([
         {
           dateType: 'CRD',
           dateText: 'CRD (Conditional release date)',
           date: { day: 3, month: 3, year: 2017 },
         } as ManualEntrySelectedDate,
-      ],
-    )
-    expect(configured).toEqual([
-      {
-        dateType: 'CRD',
-        dateText: 'CRD (Conditional release date)',
-        date: { day: 3, month: 3, year: 2017 },
-      } as ManualEntrySelectedDate,
-    ])
-  })
-  it('adds a new date type with an undefined date if not in list', () => {
-    const configured = dateTypeConfigurationService.configure(['CRD'], [])
-    expect(configured).toEqual([
-      {
-        dateType: 'CRD',
-        dateText: 'CRD (Conditional release date)',
-        date: undefined,
-      } as ManualEntrySelectedDate,
-    ])
+        {
+          dateType: 'ARD',
+          dateText: 'ARD (Automatic release date)',
+          date: { day: 4, month: 4, year: 2018 },
+        } as ManualEntrySelectedDate,
+      ])
+    })
+    it('adds a new date type with an undefined date if not in list', async () => {
+      const configured = await dateTypeConfigurationService.configureViaBackend('token', ['CRD'], [])
+      expect(configured).toEqual([
+        {
+          dateType: 'CRD',
+          dateText: 'CRD (Conditional release date)',
+          date: undefined,
+        } as ManualEntrySelectedDate,
+      ])
+    })
+    it('should format None correctly', async () => {
+      const configured = await dateTypeConfigurationService.configureViaBackend('token', ['None'], [])
+      expect(configured).toEqual([
+        {
+          dateType: 'None',
+          dateText: 'None of the above dates apply',
+          date: undefined,
+        } as ManualEntrySelectedDate,
+      ])
+    })
+    it('can load all dates as dictionary', async () => {
+      const configured = await dateTypeConfigurationService.dateTypeToDescriptionMapping('token')
+      expect(configured).toEqual({
+        CRD: 'CRD (Conditional release date)',
+        ARD: 'ARD (Automatic release date)',
+        None: 'None of the above dates apply',
+      })
+    })
   })
 })

--- a/server/services/dateTypeConfigurationService.ts
+++ b/server/services/dateTypeConfigurationService.ts
@@ -1,30 +1,16 @@
-import { ManualEntrySelectedDate } from '../@types/calculateReleaseDates/calculateReleaseDatesClientTypes'
-
-export const FULL_STRING_LOOKUP = {
-  SED: 'SED (Sentence expiry date)',
-  LED: 'LED (Licence expiry date)',
-  CRD: 'CRD (Conditional release date)',
-  HDCED: 'HDCED (Home detention curfew release date)',
-  TUSED: 'TUSED (Top up supervision expiry date)',
-  PRRD: 'PRRD (Post recall release date)',
-  PED: 'PED (Parole eligibility date)',
-  ROTL: 'ROTL (Release on temporary licence)',
-  ERSED: 'ERSED (Early removal scheme eligibility date)',
-  ARD: 'ARD (Automatic release date)',
-  HDCAD: 'HDCAD (Home detention curfew approved date)',
-  MTD: 'MTD (Mid transfer date)',
-  ETD: 'ETD (Early transfer date)',
-  LTD: 'LTD (Late transfer date)',
-  APD: 'APD (Approved parole date)',
-  NPD: 'NPD (Non-parole date)',
-  DPRRD: 'DPRRD (Detention and training order post recall release date)',
-  Tariff: 'Tariff (known as the Tariff expiry date)',
-  TERSED: 'TERSED (Tariff-expired removal scheme eligibility date)',
-  None: 'None of the above dates apply',
-}
+import {
+  DateTypeDefinition,
+  ManualEntrySelectedDate,
+} from '../@types/calculateReleaseDates/calculateReleaseDatesClientTypes'
+import CalculateReleaseDatesApiClient from '../api/calculateReleaseDatesApiClient'
 
 export default class DateTypeConfigurationService {
-  public configure(dateList: string | string[], sessionList: ManualEntrySelectedDate[]): ManualEntrySelectedDate[] {
+  public async configureViaBackend(
+    token: string,
+    dateList: string | string[],
+    sessionList: ManualEntrySelectedDate[],
+  ): Promise<ManualEntrySelectedDate[]> {
+    const dateTypeDefinitions = await new CalculateReleaseDatesApiClient(token).getDateTypeDefinitions()
     const selectedDateTypes: string[] = Array.isArray(dateList) ? dateList : [dateList]
     return selectedDateTypes
       .map((date: string) => {
@@ -33,18 +19,35 @@ export default class DateTypeConfigurationService {
           if (existingDate) {
             return {
               dateType: date,
-              dateText: FULL_STRING_LOOKUP[date],
+              dateText: this.getDescription(dateTypeDefinitions, date),
               date: existingDate.date,
             } as ManualEntrySelectedDate
           }
           return {
             dateType: date,
-            dateText: FULL_STRING_LOOKUP[date],
+            dateText: this.getDescription(dateTypeDefinitions, date),
             date: undefined,
           } as ManualEntrySelectedDate
         }
         return null
       })
       .filter(obj => obj !== null)
+  }
+
+  async dateTypeToDescriptionMapping(token: string): Promise<{ [key: string]: string }> {
+    return new CalculateReleaseDatesApiClient(token).getDateTypeDefinitions().then((defs: DateTypeDefinition[]) => {
+      return Object.fromEntries(defs.map(def => [def.type, this.fromDefinitionToDescription(def)]))
+    })
+  }
+
+  private getDescription(dateTypeDefinitions: DateTypeDefinition[], date: string) {
+    return this.fromDefinitionToDescription(dateTypeDefinitions.find((dtd: DateTypeDefinition) => dtd.type === date))
+  }
+
+  private fromDefinitionToDescription(def: DateTypeDefinition) {
+    if (def.type === 'None') {
+      return def.description
+    }
+    return `${def.type} (${def.description})`
   }
 }

--- a/server/testutils/createUserToken.ts
+++ b/server/testutils/createUserToken.ts
@@ -12,3 +12,30 @@ export default function createUserToken(authorities: string[]) {
 
   return jwt.sign(payload, 'secret', { expiresIn: '1h' })
 }
+
+export const testDateTypeDefinitions = [
+  { type: 'CRD', description: 'Conditional release date' },
+  { type: 'LED', description: 'Licence expiry date' },
+  { type: 'SED', description: 'Sentence expiry date' },
+  { type: 'NPD', description: 'Non-parole date' },
+  { type: 'ARD', description: 'Automatic release date' },
+  { type: 'TUSED', description: 'Top up supervision expiry date' },
+  { type: 'PED', description: 'Parole eligibility date' },
+  { type: 'SLED', description: 'Sentence and licence expiry date' },
+  { type: 'HDCED', description: 'Home detention curfew eligibility date' },
+  { type: 'NCRD', description: 'Notional conditional release date' },
+  { type: 'ETD', description: 'Early transfer date' },
+  { type: 'MTD', description: 'Mid transfer date' },
+  { type: 'LTD', description: 'Late transfer date' },
+  { type: 'DPRRD', description: 'Detention and training order post recall release date' },
+  { type: 'PRRD', description: 'Post recall release date' },
+  { type: 'ESED', description: 'Effective sentence end date' },
+  { type: 'ERSED', description: 'Early removal scheme eligibility date' },
+  { type: 'TERSED', description: 'Tariff-expired removal scheme eligibility date' },
+  { type: 'APD', description: 'Approved parole date' },
+  { type: 'HDCAD', description: 'Home detention curfew approved date' },
+  { type: 'None', description: 'None of the above dates apply' },
+  { type: 'Tariff', description: 'known as the Tariff expiry date' },
+  { type: 'ROTL', description: 'Release on temporary licence' },
+  { type: 'HDCED4PLUS', description: 'HDCED4+' },
+]

--- a/server/views/pages/approvedDates/removeDate.njk
+++ b/server/views/pages/approvedDates/removeDate.njk
@@ -6,7 +6,7 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% set pageTitle = applicationName + " - determinite manual entry" %}
-{% set pageId = "determinite selection" %}
+{% set pageId = "remove-approved-date" %}
 
 {% block beforeContent %}
     {{ super() }}

--- a/server/views/pages/approvedDates/selectApprovedDates.njk
+++ b/server/views/pages/approvedDates/selectApprovedDates.njk
@@ -5,7 +5,7 @@
 {%- from "moj/components/banner/macro.njk" import mojBanner -%}
 
 {% set pageTitle = applicationName + " - determinite manual entry" %}
-{% set pageId = "determinite selection" %}
+{% set pageId = "select-approved-date-types" %}
 
 {% block beforeContent %}
     {{ super() }}

--- a/server/views/pages/approvedDates/submitDate.njk
+++ b/server/views/pages/approvedDates/submitDate.njk
@@ -6,7 +6,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitle = applicationName + " - determinite manual entry" %}
-{% set pageId = "determinite selection" %}
+{% set pageId = "enter-approved-date" %}
 
 {% block beforeContent %}
     {{ super() }}


### PR DESCRIPTION
Get rid of full string lookup and use the reference data from the API instead. Also added integration tests to cover approved dates.