### PR TITLE
CRS-1875: Fix genuine overrides

### DIFF
--- a/server/routes/genuineOverrideRoutes.test.ts
+++ b/server/routes/genuineOverrideRoutes.test.ts
@@ -73,6 +73,50 @@ const stubbedCalculationResults = {
   approvedDates: {},
 } as BookingCalculation
 
+const stubbedCalculationResultsWithReason = {
+  dates: {
+    CRD: '2021-02-03',
+    SED: '2021-02-03',
+    HDCED: '2021-10-03',
+    ERSED: '2020-02-03',
+  },
+  calculationRequestId: 123456,
+  effectiveSentenceLength: {},
+  prisonerId: 'A1234AB',
+  calculationStatus: 'CONFIRMED',
+  calculationType: 'CALCULATED',
+  calculationReference: 'ABC123',
+  bookingId: 123,
+  approvedDates: {},
+  calculationReason: {
+    id: 1,
+    isOther: false,
+    displayName: 'Transfer',
+  },
+} as BookingCalculation
+
+const stubbedNewCalculationResults = {
+  dates: {
+    CRD: '2021-02-03',
+    SED: '2021-02-03',
+    HDCED: '2021-10-03',
+    ERSED: '2020-02-03',
+  },
+  calculationRequestId: 987654,
+  effectiveSentenceLength: {},
+  prisonerId: 'A1234AB',
+  calculationStatus: 'CONFIRMED',
+  calculationType: 'CALCULATED',
+  calculationReference: 'XYZ789',
+  bookingId: 123,
+  approvedDates: {},
+  calculationReason: {
+    id: 1,
+    isOther: false,
+    displayName: 'Transfer',
+  },
+} as BookingCalculation
+
 const stubbedPrisonerData = {
   offenderNo: 'A1234AA',
   firstName: 'Anon',
@@ -660,6 +704,30 @@ describe('Genuine overrides routes tests', () => {
       .expect(res => {
         expectMiniProfile(res.text, expectedMiniProfile)
       })
+  })
+  it('POST /specialist-support/calculation/:calculationReference/sentence-and-offence-information should validate and redirect to calc summary when no original calc reason', () => {
+    userPermissionsService.allowSpecialSupport.mockReturnValue(true)
+    calculateReleaseDatesService.getCalculationResultsByReference.mockResolvedValue(stubbedCalculationResults)
+    userInputService.getCalculationUserInputForPrisoner.mockReturnValue(stubbedUserInput)
+    calculateReleaseDatesService.validateBackend.mockReturnValue({ messages: [] } as never)
+    calculateReleaseDatesService.calculatePreliminaryReleaseDates.mockResolvedValue(stubbedNewCalculationResults)
+
+    return request(app)
+      .post('/specialist-support/calculation/123/sentence-and-offence-information')
+      .expect(302)
+      .expect('Location', '/specialist-support/calculation/XYZ789/summary/987654')
+  })
+  it('POST /specialist-support/calculation/:calculationReference/sentence-and-offence-information should validate and redirect to calc summary using calc reason from original calc', () => {
+    userPermissionsService.allowSpecialSupport.mockReturnValue(true)
+    calculateReleaseDatesService.getCalculationResultsByReference.mockResolvedValue(stubbedCalculationResultsWithReason)
+    userInputService.getCalculationUserInputForPrisoner.mockReturnValue(stubbedUserInput)
+    calculateReleaseDatesService.validateBackend.mockReturnValue({ messages: [] } as never)
+    calculateReleaseDatesService.calculatePreliminaryReleaseDates.mockResolvedValue(stubbedNewCalculationResults)
+
+    return request(app)
+      .post('/specialist-support/calculation/123/sentence-and-offence-information')
+      .expect(302)
+      .expect('Location', '/specialist-support/calculation/XYZ789/summary/987654')
   })
   it('GET /specialist-support/calculation/:calculationReference/complete shows check confirmation page with mini profile', () => {
     userPermissionsService.allowSpecialSupport.mockReturnValue(true)

--- a/server/routes/genuineOverrideRoutes.ts
+++ b/server/routes/genuineOverrideRoutes.ts
@@ -6,7 +6,6 @@ import { FullPageError } from '../types/FullPageError'
 import CheckInformationService from '../services/checkInformationService'
 import UserInputService from '../services/userInputService'
 import CalculationSummaryViewModel from '../models/CalculationSummaryViewModel'
-import ViewReleaseDatesService from '../services/viewReleaseDatesService'
 import logger from '../../logger'
 import { ErrorMessages, ErrorMessageType } from '../types/ErrorMessages'
 import { nunjucksEnv } from '../utils/nunjucksSetup'
@@ -44,7 +43,6 @@ export default class GenuineOverrideRoutes {
     private readonly calculateReleaseDatesService: CalculateReleaseDatesService,
     private readonly checkInformationService: CheckInformationService,
     private readonly userInputService: UserInputService,
-    private readonly viewReleaseDatesService: ViewReleaseDatesService,
     private readonly manualEntryService: ManualEntryService,
     private readonly manualCalculationService: ManualCalculationService,
     private readonly genuineOverridesEmailTemplateService: GenuineOverridesEmailTemplateService,
@@ -180,11 +178,11 @@ export default class GenuineOverrideRoutes {
       if (req.session.selectedManualEntryDates[calculation.prisonerId]) {
         req.session.selectedManualEntryDates[calculation.prisonerId] = []
       }
-
+      this.userInputService.setCalculationReasonFromBooking(req, calculation)
       const calculationRequestModel = {
         calculationUserInputs: userInputs,
-        calculationReasonId: req.session.calculationReasonId[calculation.prisonerId],
-        otherReasonDescription: req.session.otherReasonDescription[calculation.prisonerId],
+        calculationReasonId: calculation.calculationReason?.id,
+        otherReasonDescription: calculation.otherReasonDescription,
       } as CalculationRequestModel
 
       const releaseDates = await this.calculateReleaseDatesService.calculatePreliminaryReleaseDates(
@@ -193,7 +191,7 @@ export default class GenuineOverrideRoutes {
         token,
       )
       return res.redirect(
-        `/specialist-support/calculation/${calculationReference}/summary/${releaseDates.calculationRequestId}`,
+        `/specialist-support/calculation/${releaseDates.calculationReference}/summary/${releaseDates.calculationRequestId}`,
       )
     }
     throw FullPageError.notFoundError()

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -73,7 +73,6 @@ export default function Index({
     calculateReleaseDatesService,
     checkInformationService,
     userInputService,
-    viewReleaseDatesService,
     manualEntryService,
     manualCalculationService,
     genuineOverridesEmailTemplateService,

--- a/server/services/userInputService.ts
+++ b/server/services/userInputService.ts
@@ -1,5 +1,8 @@
 import { Request } from 'express'
-import { CalculationUserInputs } from '../@types/calculateReleaseDates/calculateReleaseDatesClientTypes'
+import {
+  BookingCalculation,
+  CalculationUserInputs,
+} from '../@types/calculateReleaseDates/calculateReleaseDatesClientTypes'
 
 export default class UserInputService {
   public setCalculationUserInputForPrisoner(req: Request, nomsId: string, userInputs: CalculationUserInputs): void {
@@ -21,5 +24,16 @@ export default class UserInputService {
       (req.session.userInputs && req.session.userInputs[nomsId]) ||
       ({ sentenceCalculationUserInputs: [] } as CalculationUserInputs)
     )
+  }
+
+  public setCalculationReasonFromBooking(req: Request, calculation: BookingCalculation) {
+    if (!req.session.calculationReasonId) {
+      req.session.calculationReasonId = {}
+    }
+    if (!req.session.otherReasonDescription) {
+      req.session.otherReasonDescription = {}
+    }
+    req.session.calculationReasonId[calculation.prisonerId] = calculation.calculationReason?.id
+    req.session.otherReasonDescription[calculation.prisonerId] = calculation.otherReasonDescription
   }
 }


### PR DESCRIPTION
Was blowing up with calc reason not in session (which it never could be). Now copies calc reason from original calculation.  Also was using the old reference on calc summary which is invalid with the new calculation id.