### PR TITLE
CRS-1641 & CRS-1940: SDS+ highlights

### DIFF
--- a/server/@types/calculateReleaseDates/index.d.ts
+++ b/server/@types/calculateReleaseDates/index.d.ts
@@ -752,6 +752,7 @@ export interface components {
       fineAmount?: number
       /** @enum {string} */
       sentenceAndOffenceAnalysis: 'NEW' | 'UPDATED' | 'SAME'
+      isSDSPlus: boolean
     }
     OffenderOffence: {
       /** Format: int64 */

--- a/server/models/SentenceAndOffenceViewModel.ts
+++ b/server/models/SentenceAndOffenceViewModel.ts
@@ -1,8 +1,6 @@
 import {
   AnalyzedSentenceAndOffences,
-  CalculationSentenceUserInput,
   CalculationUserInputs,
-  OffenderOffence,
 } from '../@types/calculateReleaseDates/calculateReleaseDatesClientTypes'
 import {
   AnalyzedPrisonApiBookingAndSentenceAdjustments,
@@ -28,6 +26,8 @@ export default class SentenceAndOffenceViewModel {
 
   public sentencesAndOffences: AnalyzedSentenceAndOffences[]
 
+  public displaySDSPlusBanner: boolean
+
   public constructor(
     public prisonerDetail: PrisonApiPrisoner,
     public userInputs: CalculationUserInputs,
@@ -52,16 +52,11 @@ export default class SentenceAndOffenceViewModel {
     this.offenceCount = sentencesAndOffences.reduce(reducer, 0)
     this.returnToCustodyDate = returnToCustodyDate?.returnToCustodyDate
     this.sentencesAndOffences = sentencesAndOffences
+    this.displaySDSPlusBanner = sentencesAndOffences.some(sentence => sentence.isSDSPlus === true)
   }
 
-  public rowIsSdsPlus(sentence: AnalyzedSentenceAndOffences, offence: OffenderOffence): boolean {
-    const oldUserInputForSDSPlus =
-      this.userInputs &&
-      this.userInputs.sentenceCalculationUserInputs?.find((it: CalculationSentenceUserInput) => {
-        return it.offenceCode === offence.offenceCode && it.sentenceSequence === sentence.sentenceSequence
-      })
-    const isUserIdentifiedSDSPlus = oldUserInputForSDSPlus && oldUserInputForSDSPlus.userChoice
-    return isUserIdentifiedSDSPlus || offence.isPcscSdsPlus
+  public rowIsSdsPlus(sentence: AnalyzedSentenceAndOffences): boolean {
+    return sentence.isSDSPlus === true
   }
 
   public isErsedChecked(): boolean {

--- a/server/views/pages/calculation/checkInformation.njk
+++ b/server/views/pages/calculation/checkInformation.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {%- from "moj/components/banner/macro.njk" import mojBanner -%}
+{% from "../components/sds-plus-notification-banner/macro.njk" import sdsPlusNotificationBanner %}
 
 {% set pageTitle = applicationName + " - check information" %}
 {% set pageId = "check-information" %}
@@ -22,6 +23,7 @@
     {% set validationErrors = model.validationErrors %}
     {% include "../partials/customErrorBanner.njk" %}
     {% include "../partials/multipleOffencesBanner.njk" %}
+    {% if model.displaySDSPlusBanner %}{{ sdsPlusNotificationBanner() }}{% endif %}
         <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
 

--- a/server/views/pages/components/sds-plus-notification-banner/macro.njk
+++ b/server/views/pages/components/sds-plus-notification-banner/macro.njk
@@ -1,0 +1,3 @@
+{% macro sdsPlusNotificationBanner() %}
+    {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/pages/components/sds-plus-notification-banner/template.njk
+++ b/server/views/pages/components/sds-plus-notification-banner/template.njk
@@ -1,0 +1,11 @@
+{%- from "moj/components/banner/macro.njk" import mojBanner -%}
+{% set sdsPlusBannerHtml %}
+    <h2 class="govuk-heading-m">Important</h2>
+    <p class="govuk-body">This service has identified one or more sentences where the release date is calculated at two thirds (SDS+).</p>
+    <p class="govuk-body">Make sure a peach calculation sheet has been used to calculate the release dates.</p>
+{% endset %}
+{{ mojBanner({
+    type: ' ',
+    html: sdsPlusBannerHtml,
+    attributes: { 'data-qa': 'sds-plus-notification-banner' }
+}) }}

--- a/server/views/pages/genuineOverrides/checkInformation.njk
+++ b/server/views/pages/genuineOverrides/checkInformation.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {%- from "moj/components/banner/macro.njk" import mojBanner -%}
+{% from "../components/sds-plus-notification-banner/macro.njk" import sdsPlusNotificationBanner %}
 
 {% set pageTitle = applicationName + " - check information" %}
 {% set pageId = "check-information" %}
@@ -22,6 +23,7 @@
     {% set validationErrors = model.validationErrors %}
     {% include "../partials/customErrorBanner.njk" %}
     {% include "../partials/multipleOffencesBanner.njk" %}
+    {% if model.displaySDSPlusBanner %}{{ sdsPlusNotificationBanner() }}{% endif %}
         <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
 

--- a/server/views/pages/manualEntry/checkInformationUnsupported.njk
+++ b/server/views/pages/manualEntry/checkInformationUnsupported.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {%- from "moj/components/banner/macro.njk" import mojBanner -%}
+{% from "../components/sds-plus-notification-banner/macro.njk" import sdsPlusNotificationBanner %}
 
 {% set pageTitle = applicationName + " - check information" %}
 {% set pageId = "check-information-unsupported" %}
@@ -22,6 +23,7 @@
     {% set validationErrors = model.validationErrors %}
     {% include "../partials/customErrorBanner.njk" %}
     {% include "../partials/multipleOffencesBanner.njk" %}
+    {% if model.displaySDSPlusBanner %}{{ sdsPlusNotificationBanner() }}{% endif %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
 


### PR DESCRIPTION
Add SDS+ notification banner on check information page if any sentence is SDS+. Also changed to use new isSDSPlus flag for SDS+ badge as using indicators was causing NOMIS flagged sentences to show as SDS+ even if they weren't SDS sentences or were too short.