### PR TITLE
Display Offence Code with Offence description

### DIFF
--- a/integration_tests/e2e/happyPath.cy.ts
+++ b/integration_tests/e2e/happyPath.cy.ts
@@ -108,6 +108,7 @@ context('End to end happy path of user journey', () => {
 
     const checkInformationPage = Page.verifyOnPage(ViewSentencesAndOffencesPage)
     checkInformationPage.offenceCountText().contains('This calculation will include 2 sentences from NOMIS.')
+    checkInformationPage.offenceTitle('123').should('have.text', '123 - Doing a crime')
     checkInformationPage.nextPage().click()
 
     const calculationSummaryPage = Page.verifyOnPage(ViewCalculationSummary)

--- a/integration_tests/pages/sentencesAndOffencesCommon.ts
+++ b/integration_tests/pages/sentencesAndOffencesCommon.ts
@@ -17,6 +17,10 @@ export default class ViewSentencesAndOffencesCommon extends Page {
     return cy.get(`[data-qa=summary-tab-link]`)
   }
 
+  public offenceTitle(offenceCode: string): PageElement {
+    return cy.get(`[data-qa=${offenceCode}-title]`)
+  }
+
   public adjustmentSummary(): PageElement {
     return cy.get(`#summary`)
   }

--- a/server/routes/checkInformationRoutes.test.ts
+++ b/server/routes/checkInformationRoutes.test.ts
@@ -158,7 +158,7 @@ const stubbedSentencesAndOffences = [
       {
         offenderChargeId: 2,
         offenceStartDate: '2020-01-01',
-        offenceCode: 'RL05016',
+        offenceCode: 'RL05017',
         offenceDescription: 'Access / exit by unofficial route - railway bye-law',
       },
     ],
@@ -431,7 +431,7 @@ describe('Check information routes tests', () => {
       })
   })
 
-  it('GET /calculation/:nomsId/check-information back button should return to dps start page if no calc questions', () => {
+  it('GET /calculation/:nomsId/check-information correct offence title, back button should return to dps start page if no calc questions', () => {
     calculateReleaseDatesService.getUnsupportedSentenceOrCalculationMessages.mockResolvedValue(stubbedEmptyMessages)
     prisonerService.getReturnToCustodyDate.mockResolvedValue(stubbedReturnToCustodyDate)
     const model = new SentenceAndOffenceViewModel(
@@ -449,6 +449,10 @@ describe('Check information routes tests', () => {
       .expect(200)
       .expect('Content-Type', /html/)
       .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-qa=RL05016-title]').text()).toStrictEqual(
+          'RL05016 - Access / exit by unofficial route - railway bye-law',
+        )
         expect(res.text).toContain('href="/?prisonId=A1234AA"')
       })
   })
@@ -880,7 +884,7 @@ describe('Check information routes tests', () => {
       })
   })
 
-  it('GET /calculation/:nomsId/check-information-unsupported loads page and displays a mini profile', () => {
+  it('GET /calculation/:nomsId/check-information-unsupported loads page and displays a mini profile and correct offence title', () => {
     calculateReleaseDatesService.getUnsupportedSentenceOrCalculationMessages.mockResolvedValue([
       {
         type: 'UNSUPPORTED_SENTENCE',
@@ -900,6 +904,10 @@ describe('Check information routes tests', () => {
       .get('/calculation/A1234AA/check-information-unsupported')
       .expect(200)
       .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-qa=RL05016-title]').text()).toStrictEqual(
+          'RL05016 - Access / exit by unofficial route - railway bye-law',
+        )
         expectMiniProfile(res.text, expectedMiniProfile)
       })
   })

--- a/server/routes/genuineOverrideRoutes.test.ts
+++ b/server/routes/genuineOverrideRoutes.test.ts
@@ -190,7 +190,7 @@ const stubbedSentencesAndOffences = [
     consecutiveToSequence: 1,
     sentenceCalculationType: 'ADIMP',
     sentenceTypeDescription: 'SDS Standard Sentence',
-    offences: [{ offenceEndDate: '2021-02-03', offenceCode: '123' }],
+    offences: [{ offenceEndDate: '2021-02-03', offenceCode: '123', offenceDescription: 'Doing a crime' }],
     isSDSPlus: true,
   } as AnalyzedSentenceAndOffences,
 ]
@@ -688,7 +688,7 @@ describe('Genuine overrides routes tests', () => {
       })
   })
 
-  it('GET /specialist-support/calculation/:calculationReference/sentence-and-offence-information shows check information page with mini profile', () => {
+  it('GET /specialist-support/calculation/:calculationReference/sentence-and-offence-information shows check information page with mini profile and correct offence title', () => {
     userPermissionsService.allowSpecialSupport.mockReturnValue(true)
     const model = new SentenceAndOffenceViewModel(
       stubbedPrisonerData,
@@ -705,6 +705,8 @@ describe('Genuine overrides routes tests', () => {
       .expect(200)
       .expect('Content-Type', /html/)
       .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-qa=123-title]').text()).toStrictEqual('123 - Doing a crime')
         expectMiniProfile(res.text, expectedMiniProfile)
       })
   })

--- a/server/routes/viewRoutes.test.ts
+++ b/server/routes/viewRoutes.test.ts
@@ -128,7 +128,7 @@ const stubbedSentencesAndOffences = [
     consecutiveToSequence: 1,
     sentenceCalculationType: 'ADIMP',
     sentenceTypeDescription: 'SDS Standard Sentence',
-    offences: [{ offenceEndDate: '2021-02-03', offenceCode: '123' }],
+    offences: [{ offenceEndDate: '2021-02-03', offenceCode: '123', offenceDescription: 'Doing a crime' }],
     isSDSPlus: false,
   } as SentenceAndOffencesWithReleaseArrangements,
 ]
@@ -458,6 +458,8 @@ describe('View journey routes tests', () => {
         .expect(200)
         .expect('Content-Type', /html/)
         .expect(res => {
+          const $ = cheerio.load(res.text)
+          expect($('[data-qa=123-title]').text()).toStrictEqual('123 - Doing a crime')
           expect(res.text).toContain('A1234AA')
           expect(res.text).toContain('Anon')
           expect(res.text).toContain('Nobody')

--- a/server/views/pages/partials/checkInformation/sentenceCard.njk
+++ b/server/views/pages/partials/checkInformation/sentenceCard.njk
@@ -21,7 +21,7 @@
                             </h3>
                 {% endif %}
                         {#                        {% endif %} #}
-                        <h4 class="govuk-heading-s govuk-!-margin-bottom-1">{{ offence.offenceDescription }}</h4>
+                        <h4 class="govuk-heading-s govuk-!-margin-bottom-1" data-qa="{{offence.offenceCode }}-title">{{offence.offenceCode }} - {{ offence.offenceDescription }}</h4>
                         <p class="govuk-body-s">
                             {% if (offence.offenceEndDate and offence.offenceStartDate and offence.offenceEndDate !== offence.offenceStartDate) %}
                         Committed from {{ offence.offenceStartDate | date('DD MMMM YYYY') }} to {{ offence.offenceEndDate | date('DD MMMM YYYY') }}

--- a/server/views/pages/partials/genuineOverrides/sentenceCard.njk
+++ b/server/views/pages/partials/genuineOverrides/sentenceCard.njk
@@ -9,7 +9,7 @@
                 <div class="govuk-!-margin-bottom-6 sentence-card flex">
                     <div class="govuk-grid-column-full govuk-!-margin-top-4">
                         <h3 class="govuk-body-s govuk-!-margin-bottom-0">Count {{ sentence.lineSequence }}</h3>
-                        <h4 class="govuk-heading-s govuk-!-margin-bottom-1">{{ offence.offenceDescription }}</h4>
+                        <h4 class="govuk-heading-s govuk-!-margin-bottom-1" data-qa="{{offence.offenceCode }}-title">{{offence.offenceCode}} - {{ offence.offenceDescription }}</h4>
                         <p class="govuk-body-s">
                             {% if (offence.offenceEndDate and offence.offenceStartDate and offence.offenceEndDate !== offence.offenceStartDate) %}
                         Committed from {{ offence.offenceStartDate | date('DD MMMM YYYY') }} to {{ offence.offenceEndDate | date('DD MMMM YYYY') }}


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/CRS-1945
The following routes and relevant tests has been amended to display the Offence code with offence description

/calculation/:nomsId/check-information
/calculation/:nomsId/check-information-unsupported
/specialist-support/calculation/:calculationReference/sentence-and-offence-information /view/:calculationRequestId/sentences-and-offences

The integration test has also been amended to test for this info.