### PR TITLE
Increate timeout for calculatereleasedates api for pre-prod

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -25,6 +25,8 @@ generic-service:
     COMPONENT_API_URL: "https://frontend-components-preprod.hmpps.service.justice.gov.uk"
     COURT_CASES_AND_RELEASE_DATES_URL: "https://court-cases-release-dates-preprod.hmpps.service.justice.gov.uk"
     FRONTEND_COMPONENT_API_TIMEOUT: 500
+    CALCULATE_RELEASE_DATES_API_TIMEOUT_RESPONSE: 15000
+    CALCULATE_RELEASE_DATES_API_TIMEOUT_DEADLINE: 15000
     HDC4_PLUS_COMPARISON_TAB_ENABLED: "true"
     ENVIRONMENT_NAME: PRE-PRODUCTION
 


### PR DESCRIPTION
* Bulk comparison in preprod is taking a little longer to return, temporarily bumping the timeout whilst the root cause can be identified and improvements made.