### PR TITLE
Bump front end timeout for calls to CRDS API

### DIFF
--- a/helm_deploy/values-alt-preprod.yaml
+++ b/helm_deploy/values-alt-preprod.yaml
@@ -25,6 +25,8 @@ generic-service:
     COMPONENT_API_URL: "https://frontend-components-preprod.hmpps.service.justice.gov.uk"
     COURT_CASES_AND_RELEASE_DATES_URL: "https://court-cases-release-dates-preprod.hmpps.service.justice.gov.uk"
     FRONTEND_COMPONENT_API_TIMEOUT: 500
+    CALCULATE_RELEASE_DATES_API_TIMEOUT_RESPONSE: 60000
+    CALCULATE_RELEASE_DATES_API_TIMEOUT_DEADLINE: 60000
     HDC4_PLUS_COMPARISON_TAB_ENABLED: "true"
     ENVIRONMENT_NAME: PRE-PRODUCTION
 


### PR DESCRIPTION
* Apply the same timeout to the front end as applied to preprod for bulk calc taking a while.
N.B The SDS SI analysis has been largely completed on the alt-preprod env