### PR TITLE
Bump CRDS API request timeout for slow running bulk comparison

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -20,6 +20,8 @@ generic-service:
     COMPONENT_API_URL: "https://frontend-components.hmpps.service.justice.gov.uk"
     COURT_CASES_AND_RELEASE_DATES_URL: "https://court-cases-release-dates.hmpps.service.justice.gov.uk"
     FRONTEND_COMPONENT_API_TIMEOUT: 500
+    CALCULATE_RELEASE_DATES_API_TIMEOUT_RESPONSE: 60000
+    CALCULATE_RELEASE_DATES_API_TIMEOUT_DEADLINE: 60000
     HDC4_PLUS_COMPARISON_TAB_ENABLED: "false"
 generic-prometheus-alerts:
   alertSeverity: legacy-replacement-alerts


### PR DESCRIPTION
* Apply same CRDS API timeout bump to prod, as was applied to preprod and alt-preprod