### PR TITLE
Display Ersed Not applicable banner based flag returned from API

### DIFF
--- a/integration_tests/mockApis/calculateReleaseDatesApi.ts
+++ b/integration_tests/mockApis/calculateReleaseDatesApi.ts
@@ -853,6 +853,7 @@ export default {
         },
       },
       otherDates: {},
+      ersedNotApplicableDueToDtoLaterThanCrd: false,
     }
     const prisonerDetails = {
       offenderNo: 'A1234AB',

--- a/server/@types/calculateReleaseDates/index.d.ts
+++ b/server/@types/calculateReleaseDates/index.d.ts
@@ -1184,6 +1184,7 @@ export interface components {
       otherDates: {
         [key: string]: string
       }
+      ersedNotApplicableDueToDtoLaterThanCrd: boolean
     }
     CalculationOriginalData: {
       prisonerDetails?: components['schemas']['PrisonerDetails']

--- a/server/models/CalculationSummaryViewModel.ts
+++ b/server/models/CalculationSummaryViewModel.ts
@@ -61,16 +61,4 @@ export default class CalculationSummaryViewModel {
     }
     return false
   }
-
-  public ersedNotApplicableDueToDtoLaterThanCrd(): boolean {
-    const ersedBeforeCrd = this.dateBeforeAnother(
-      this.detailedCalculationResults.dates?.ERSED?.date,
-      this.detailedCalculationResults.dates?.CRD?.date,
-    )
-    const crdBeforeMtd = this.dateBeforeAnother(
-      this.detailedCalculationResults.dates?.CRD?.date,
-      this.detailedCalculationResults.dates?.MTD?.date,
-    )
-    return ersedBeforeCrd && crdBeforeMtd
-  }
 }

--- a/server/routes/genuineOverrideRoutes.test.ts
+++ b/server/routes/genuineOverrideRoutes.test.ts
@@ -333,6 +333,7 @@ const stubbedCalculationBreakdown: CalculationBreakdown = {
   ],
   breakdownByReleaseDateType: {},
   otherDates: {},
+  ersedNotApplicableDueToDtoLaterThanCrd: false,
 }
 
 const stubbedResultsWithBreakdownAndAdjustments: ResultsWithBreakdownAndAdjustments = {

--- a/server/routes/viewRoutes.test.ts
+++ b/server/routes/viewRoutes.test.ts
@@ -252,6 +252,7 @@ const stubbedCalculationBreakdown: CalculationBreakdown = {
   ],
   breakdownByReleaseDateType: {},
   otherDates: {},
+  ersedNotApplicableDueToDtoLaterThanCrd: false,
 }
 
 const stubbedReleaseDatesWithAdjustments: ReleaseDateWithAdjustments[] = [

--- a/server/services/breakdownExamplesTestData.ts
+++ b/server/services/breakdownExamplesTestData.ts
@@ -68,6 +68,7 @@ export function psiExample16CalculationBreakdown(): CalculationBreakdown {
       },
     },
     otherDates: {},
+    ersedNotApplicableDueToDtoLaterThanCrd: false,
   }
 }
 
@@ -139,6 +140,7 @@ export function psiExample25CalculationBreakdown(): CalculationBreakdown {
       },
     },
     otherDates: {},
+    ersedNotApplicableDueToDtoLaterThanCrd: false,
   }
 }
 
@@ -226,6 +228,7 @@ export function pedAdjustedByCrdAndBeforePrrdBreakdown(): CalculationBreakdown {
       },
     },
     otherDates: { PRRD: '2025-03-18' },
+    ersedNotApplicableDueToDtoLaterThanCrd: false,
   }
 }
 
@@ -302,6 +305,7 @@ export function hdcedAdjustedToArd(): CalculationBreakdown {
       },
     },
     otherDates: {},
+    ersedNotApplicableDueToDtoLaterThanCrd: false,
   }
 }
 
@@ -539,6 +543,7 @@ export function ersedHalfwayBreakdown(): CalculationBreakdown {
       },
     },
     otherDates: {},
+    ersedNotApplicableDueToDtoLaterThanCrd: false,
   }
 }
 export function ersedTwoThirdsBreakdown(): CalculationBreakdown {
@@ -555,6 +560,7 @@ export function ersedTwoThirdsBreakdown(): CalculationBreakdown {
       },
     },
     otherDates: {},
+    ersedNotApplicableDueToDtoLaterThanCrd: false,
   }
 }
 export function ersedAdjustedByArdBreakdown(): CalculationBreakdown {
@@ -571,6 +577,7 @@ export function ersedAdjustedByArdBreakdown(): CalculationBreakdown {
       },
     },
     otherDates: {},
+    ersedNotApplicableDueToDtoLaterThanCrd: false,
   }
 }
 export function ersedBeforeSentenceBreakdown(): CalculationBreakdown {
@@ -587,5 +594,6 @@ export function ersedBeforeSentenceBreakdown(): CalculationBreakdown {
       },
     },
     otherDates: {},
+    ersedNotApplicableDueToDtoLaterThanCrd: false,
   }
 }

--- a/server/services/calculateReleaseDatesService.test.ts
+++ b/server/services/calculateReleaseDatesService.test.ts
@@ -92,6 +92,7 @@ const calculationBreakdown: CalculationBreakdown = {
   ],
   breakdownByReleaseDateType: {},
   otherDates: {},
+  ersedNotApplicableDueToDtoLaterThanCrd: false,
 }
 
 const validResult: ValidationMessage[] = []
@@ -809,6 +810,7 @@ describe('Calculate release dates service tests', () => {
             },
           },
           otherDates: {},
+          ersedNotApplicableDueToDtoLaterThanCrd: false,
         },
       }
       fakeApi.get(`/calculation/detailed-results/${calculationRequestId}`).reply(200, detailedResultsWithABreakdown)

--- a/server/views/pages/partials/ersedCannotHappenNotificationBanner.njk
+++ b/server/views/pages/partials/ersedCannotHappenNotificationBanner.njk
@@ -1,9 +1,9 @@
 {%- from "moj/components/banner/macro.njk" import mojBanner -%}
 
-{% if model.ersedNotApplicableDueToDtoLaterThanCrd() %}
+{% if model.calculationBreakdown.ersedNotApplicableDueToDtoLaterThanCrd %}
     {% set ersedNotApplicableHtml %}
-        <h2 class="govuk-heading-m">Important</h2>
-        <p class="govuk-body">Early removal cannot happen as release from the Detention Training Order (DTO) is later than the Conditional Release Date (CRD).</p>
+        <h2 data-qa="important-title" class="govuk-heading-m">Important</h2>
+        <p data-qa="ersed-na-banner" class="govuk-body">Early removal cannot happen as release from the Detention Training Order (DTO) is later than the Conditional Release Date (CRD).</p>
     {% endset %}
     {{ mojBanner({
         type: ' ',


### PR DESCRIPTION
This change is to display the ERSED Not applicable banner based on a flag returned in calculation breakdown - getResultsWithBreakdownAndAdjustments CRD-api and remove the logic that was in place before this change. 