### PR TITLE
Redirect check-information back to calc reason if not set

### DIFF
--- a/integration_tests/e2e/checkInformation.cy.ts
+++ b/integration_tests/e2e/checkInformation.cy.ts
@@ -1,4 +1,5 @@
 import CheckInformationPage from '../pages/checkInformation'
+import CalculationReasonPage from '../pages/reasonForCalculation'
 
 context('Check nomis information', () => {
   beforeEach(() => {
@@ -7,6 +8,7 @@ context('Check nomis information', () => {
     cy.task('stubManageUser')
     cy.task('stubGetPrisonerDetails')
     cy.task('stubGetSentencesAndOffences')
+    cy.task('stubGetActiveCalculationReasons')
     cy.task('stubGetAnalyzedSentencesAndOffences')
     cy.task('stubGetAnalyzedSentenceAdjustments')
     cy.task('stubGetUserCaseloads')
@@ -16,7 +18,14 @@ context('Check nomis information', () => {
 
   it('Visit check nomis information page', () => {
     cy.signIn()
-    const checkInformationPage = CheckInformationPage.goTo('A1234AB')
+
+    CalculationReasonPage.goTo('A1234AB')
+    const calculationReasonPage = CalculationReasonPage.verifyOnPage(CalculationReasonPage)
+    calculationReasonPage.radioByIndex(1).check()
+    calculationReasonPage.hasMiniProfile()
+    calculationReasonPage.submitReason().click()
+
+    const checkInformationPage = CheckInformationPage.verifyOnPage(CheckInformationPage)
     checkInformationPage.offenceCountText().contains('This calculation will include 2 sentences from NOMIS.') // contain.text didn't like the whitespace
 
     checkInformationPage.sentenceCards(1).should('contain.text', 'Committed on 03 February 2021')
@@ -37,7 +46,13 @@ context('Check nomis information', () => {
 
   it('Check nomis information page is accessible', () => {
     cy.signIn()
-    CheckInformationPage.goTo('A1234AB')
+    CalculationReasonPage.goTo('A1234AB')
+    const calculationReasonPage = CalculationReasonPage.verifyOnPage(CalculationReasonPage)
+    calculationReasonPage.radioByIndex(1).check()
+    calculationReasonPage.hasMiniProfile()
+    calculationReasonPage.submitReason().click()
+
+    CheckInformationPage.verifyOnPage(CheckInformationPage)
     cy.injectAxe()
     cy.checkA11y()
   })

--- a/integration_tests/pages/checkInformation.ts
+++ b/integration_tests/pages/checkInformation.ts
@@ -6,11 +6,6 @@ export default class CheckInformationPage extends ViewSentencesAndOffencesCommon
     super('check-information')
   }
 
-  public static goTo(prisonerId: string): CheckInformationPage {
-    cy.visit(`/calculation/${prisonerId}/check-information`)
-    return new CheckInformationPage()
-  }
-
   public calculateButton(): PageElement {
     return cy.get('[data-qa=calculate-release-dates]')
   }

--- a/server/routes/checkInformationRoutes.ts
+++ b/server/routes/checkInformationRoutes.ts
@@ -19,6 +19,9 @@ export default class CheckInformationRoutes {
   public checkInformation: RequestHandler = async (req, res): Promise<void> => {
     const { token } = res.locals.user
     const { nomsId } = req.params
+    if (!this.userInputService.isCalculationReasonSet(req, nomsId)) {
+      return res.redirect(`/calculation/${nomsId}/reason`)
+    }
     const unsupportedSentenceOrCalculationMessages =
       await this.calculateReleaseDatesService.getUnsupportedSentenceOrCalculationMessages(nomsId, token)
 

--- a/server/services/userInputService.ts
+++ b/server/services/userInputService.ts
@@ -36,4 +36,8 @@ export default class UserInputService {
     req.session.calculationReasonId[calculation.prisonerId] = calculation.calculationReason?.id
     req.session.otherReasonDescription[calculation.prisonerId] = calculation.otherReasonDescription
   }
+
+  public isCalculationReasonSet(req: Request, nomsId: string): boolean {
+    return req.session.calculationReasonId && req.session.calculationReasonId[nomsId]
+  }
 }


### PR DESCRIPTION
This happens when someone sends you a check-information link or you navigate using the browser functions after a session expiry. You would subsequently get an error when trying to run a calculation and be returned to the wrong place.