### PR TITLE
Design adjustments

### DIFF
--- a/server/views/pages/partials/printNotification/prisonerDetails.njk
+++ b/server/views/pages/partials/printNotification/prisonerDetails.njk
@@ -1,6 +1,6 @@
 {% macro prisonerDetails(model) %}
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-half">
+      <div class="govuk-grid-column-full">
         <dl class="govuk-summary-list govuk-summary-list--no-border">
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key govuk-!-font-weight-regular" style="padding: 5px 0px 6px 0px">


### PR DESCRIPTION
This fix to avoid printing name in 2 lines.
This fix allows enough space to display the name in 1 line. 