### PR TITLE
CRS-1856-Improvements

### DIFF
--- a/server/routes/viewRoutes.test.ts
+++ b/server/routes/viewRoutes.test.ts
@@ -1222,6 +1222,8 @@ describe('View journey routes tests', () => {
           const establishmentSlipLink = $('[data-qa="slip-establishment-copy"]').first()
           const daysInUnusedRemand = $('[data-qa=days-in-unusedRemand]').first()
           const offenderHDCED = $('[data-qa="offender-hdced-text"]').first()
+          const calcReasonTitle = $('[data-qa="calculation-reason-title"]')
+          const calcReason = $('[data-qa="calculation-reason"]')
 
           expect(offenderSlipLink.attr('href')).toStrictEqual(
             '/view/A1234AA/calculation-summary/123456/printNotificationSlip?fromPage=view&pageType=offender',
@@ -1232,7 +1234,7 @@ describe('View journey routes tests', () => {
           expect(backLink.attr('href')).toStrictEqual('/?prisonId=A1234AA')
           expect(offenderSlipBtn.text()).toContain('Print notification slip')
           expect(establishmentSlipBtn.text()).toContain('Print establishment copy')
-          expect(pageTitle.text()).toContain('Release date notification slip')
+          expect(pageTitle.text()).toContain('Release dates notification slip')
           expect(prisonTitle.text()).toContain('Foo Prison (HMP)')
           expect(prisonerName.text()).toContain('Anon Nobody')
           expect(prisonerCell.text()).toContain('D-2-003')
@@ -1280,6 +1282,8 @@ describe('View journey routes tests', () => {
           expect(appealBail.text()).toContain(
             'Days spent on bail pending appeal not to count (must be completed manually):',
           )
+          expect(calcReasonTitle.text()).toContain('Calculation reason')
+          expect(calcReason.text()).toContain('A calculation reason')
         })
     })
 
@@ -1305,8 +1309,8 @@ describe('View journey routes tests', () => {
 
           expect(printInvoker.attr('src')).toStrictEqual('/assets/print.js')
           expect(calculatedBy.length).toStrictEqual(0)
-          expect(calcReasonTitle.length).toStrictEqual(0)
-          expect(calcReason.length).toStrictEqual(0)
+          expect(calcReasonTitle.text()).toContain('Calculation reason')
+          expect(calcReason.text()).toContain('A calculation reason')
           expect(checkedBy.length).toStrictEqual(0)
           expect(pageTitleCaption.text()).toStrictEqual("[Anon Nobody's copy]")
           expect(offenderHDCED.text()).toStrictEqual(

--- a/server/views/pages/printNotification/printNotificationSlip.njk
+++ b/server/views/pages/printNotification/printNotificationSlip.njk
@@ -65,7 +65,7 @@
                     No agency name available
                   {% endif %}
                 </span>
-                <h1 class="govuk-heading-l" data-qa="page-title">Release date notification slip</h1>
+                <h1 class="govuk-heading-l" data-qa="page-title">Release dates notification slip</h1>
               </div>
             </div>
 
@@ -75,18 +75,16 @@
               <div class="govuk-grid-column-full">
                 <p class="govuk-body" data-qa="calculation-date">These release dates were calculated on {{ calculationDate | date('DD MMMM YYYY') }}.</p>
 
-                {% if pageType == 'establishment' %}
-                    <dl class="govuk-summary-list govuk-summary-list--no-border govuk-!-margin-bottom-4">
-                        <div class="govuk-summary-list__row">
-                            <dt data-qa="calculation-reason-title" class="govuk-summary-list__key govuk-!-font-weight-regular" style="padding: 5px 0px 6px 0px">
-                                Calculation reason
-                            </dt>
-                            <dd data-qa="calculation-reason" class="govuk-summary-list__value " style="padding: 5px 0px 6px 0px">
-                                {{ calculationReason }}
-                            </dd>
-                        </div>
-                    </dl>
-                {% endif %}
+                <dl class="govuk-summary-list govuk-summary-list--no-border govuk-!-margin-bottom-4">
+                    <div class="govuk-summary-list__row">
+                        <dt data-qa="calculation-reason-title" class="govuk-summary-list__key govuk-!-font-weight-regular" style="padding: 5px 0px 6px 0px">
+                            Calculation reason
+                        </dt>
+                        <dd data-qa="calculation-reason" class="govuk-summary-list__value " style="padding: 5px 0px 6px 0px">
+                            {{ calculationReason }}
+                        </dd>
+                    </div>
+                </dl>
 
                 {% if hasOnlyDTOSentences == false %}
                     <h2 class="govuk-heading-m govuk-!-margin-bottom-2" data-qa="release-date-title">Release dates</h2>


### PR DESCRIPTION
Improvements.
1. Fixing title text (Release dates notification slip)
2. Enabling Calculation Reason on the landing page as well as offender and establishments print slips.