### PR TITLE
Enable breakdown in alt environments

### DIFF
--- a/helm_deploy/values-alt-dev.yaml
+++ b/helm_deploy/values-alt-dev.yaml
@@ -30,6 +30,7 @@ generic-service:
     HDC4_PLUS_COMPARISON_TAB_ENABLED: "true"
     PRINT_NOTIFICATION_SLIP_ENABLED: "false"
     HDC4_BANNER_ENABLED: "true"
+    SHOW_BREAKDOWN: "true"
   # Switches off the allow list in the DEV env only.
   allowlist: null
 

--- a/helm_deploy/values-alt-preprod.yaml
+++ b/helm_deploy/values-alt-preprod.yaml
@@ -31,6 +31,7 @@ generic-service:
     PRINT_NOTIFICATION_SLIP_ENABLED: "true"
     HDC4_BANNER_ENABLED: "true"
     ENVIRONMENT_NAME: PRE-PRODUCTION
+    SHOW_BREAKDOWN: "true"
 
 generic-prometheus-alerts:
   targetApplication: calculate-release-dates-alt-preprod


### PR DESCRIPTION
* Re-enables breakdown for alt envs, whilst for other envs it remains suppressed due to recent HDC changes