### PR TITLE
Improving log message - To help with troubleshooting an issue

### DIFF
--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -56,13 +56,15 @@ export default class RestClient {
   }: Request): Promise<Response> {
     logger.info(`${this.name} GET: ${path}`)
     try {
+      const url = this.apiUrl() + path
       const result = await superagent
-        .get(`${this.apiUrl()}${path}`)
+        .get(url)
         .query(query)
         .agent(this.agent)
         .use(restClientMetricsMiddleware)
         .retry(2, (err, res) => {
-          if (err) logger.info(`Retry handler found ${this.name} API error with ${err.code} ${err.message}`)
+          if (err)
+            logger.info(`Retry handler found ${this.name} for url ${url} and error with ${err.code} ${err.message}`)
           return undefined // retry handler only for logging retries, not to influence retry logic
         })
         .auth(this.token, { type: 'bearer' })


### PR DESCRIPTION
When trying to debug an issue with bulk comparison.
The following error was displayed in CRDS - 
10:09:43.233Z  INFO Calculate Release Dates: Retry handler found Calculate release dates API API error with ECONNABORTED Timeout of 60000ms exceeded

and there is no associated failure in CRDS API.

So, Improving log messages as it is difficult to determine which url has failed and fallen into retry.
Hence adding url to the log message.