### PR TITLE
Revert "CRS-2021 Change to remove New and Updated Tags from Sent and Offence Screen"

### DIFF
--- a/server/routes/checkInformationRoutes.test.ts
+++ b/server/routes/checkInformationRoutes.test.ts
@@ -547,10 +547,12 @@ describe('Check information routes tests', () => {
 
         const $ = cheerio.load(res.text)
         // All but 1 sentences are flagged as 'NEW'
-        expect($('.sentence-card')).toHaveLength(11)
+        expect($('.govuk-tag.govuk-tag--moj-blue:contains("NEW")')).toHaveLength(10)
+        expect($('.new-sentence-card')).toHaveLength(10)
+        expect($('.sentence-card')).toHaveLength(1)
         // 5 offences in the only SDS+ sentence
         expect($('.moj-badge.moj-badge--small:contains("SDS+")')).toHaveLength(5)
-        expect($('.sentence-card:contains("Rape of a minor")').text()).toContain('SDS+')
+        expect($('.new-sentence-card:contains("Rape of a minor")').text()).toContain('SDS+')
       })
   })
   it('GET /calculation/:nomsId/check-information should show exclusions with feature toggle on for single sentence', () => {
@@ -597,7 +599,7 @@ describe('Check information routes tests', () => {
       .expect('Content-Type', /html/)
       .expect(res => {
         const $ = cheerio.load(res.text)
-        expect($('.sentence-card:contains("VIOOFFENCE")').text()).toContain('Violent')
+        expect($('.new-sentence-card:contains("VIOOFFENCE")').text()).toContain('Violent')
       })
   })
   it('GET /calculation/:nomsId/check-information should show exclusions with feature toggle on', () => {
@@ -622,9 +624,9 @@ describe('Check information routes tests', () => {
       .expect('Content-Type', /html/)
       .expect(res => {
         const $ = cheerio.load(res.text)
-        expect($('.sentence-card:contains("SXOFFENCE")').text()).toContain('Sexual')
-        expect($('.sentence-card:contains("VIOOFFENCE")').text()).toContain('Violent')
-        const noExclusionCard = $('.sentence-card:contains("No exclusion offence")')
+        expect($('.new-sentence-card:contains("SXOFFENCE")').text()).toContain('Sexual')
+        expect($('.new-sentence-card:contains("VIOOFFENCE")').text()).toContain('Violent')
+        const noExclusionCard = $('.new-sentence-card:contains("No exclusion offence")')
         expect(noExclusionCard.text()).not.toContain('Sexual')
         expect(noExclusionCard.text()).not.toContain('Violent')
       })
@@ -651,9 +653,9 @@ describe('Check information routes tests', () => {
       .expect('Content-Type', /html/)
       .expect(res => {
         const $ = cheerio.load(res.text)
-        expect($('.sentence-card:contains("SXOFFENCE")').text()).not.toContain('Sexual')
-        expect($('.sentence-card:contains("VIOOFFENCE")').text()).not.toContain('Violent')
-        const noExclusionCard = $('.sentence-card:contains("No exclusion offence")')
+        expect($('.new-sentence-card:contains("SXOFFENCE")').text()).not.toContain('Sexual')
+        expect($('.new-sentence-card:contains("VIOOFFENCE")').text()).not.toContain('Violent')
+        const noExclusionCard = $('.new-sentence-card:contains("No exclusion offence")')
         expect(noExclusionCard.text()).not.toContain('Sexual')
         expect(noExclusionCard.text()).not.toContain('Violent')
       })
@@ -906,7 +908,7 @@ describe('Check information routes tests', () => {
           expect(res.text).toContain('Court case 1 count 1 must include an offence date')
           const $ = cheerio.load(res.text)
           expect($('.moj-badge.moj-badge--small:contains("SDS+")')).toHaveLength(5)
-          expect($('.sentence-card:contains("Rape of a minor")').text()).toContain('SDS+')
+          expect($('.new-sentence-card:contains("Rape of a minor")').text()).toContain('SDS+')
           expect($('[data-qa=sds-plus-notification-banner]')).toHaveLength(1)
         })
 

--- a/server/views/pages/partials/checkInformation/sentenceCard.njk
+++ b/server/views/pages/partials/checkInformation/sentenceCard.njk
@@ -6,10 +6,20 @@
             {% set sentence = sentenceModel.sentencesAndOffence %}
             {% set offence = sentence.offence %}
 
+                {% if sentence.sentenceAndOffenceAnalysis and sentence.sentenceAndOffenceAnalysis !== 'SAME' %}
+                <div class="govuk-!-margin-bottom-6 new-sentence-card flex">
+                    <div class="govuk-grid-column-full govuk-!-margin-top-4">
+                        <h3 class="govuk-body-s govuk-!-margin-bottom-0">Count {{ sentence.lineSequence }}
+                            <span class="govuk-!-margin-left-4">
+                                <strong class="govuk-tag govuk-tag--moj-blue">{{ sentence.sentenceAndOffenceAnalysis }}</strong>
+                            </span>
+                        </h3>
+                {% else %}
                     <div class="govuk-!-margin-bottom-6 sentence-card flex">
                         <div class="govuk-grid-column-full govuk-!-margin-top-4">
                             <h3 class="govuk-body-s govuk-!-margin-bottom-0">Count {{ sentence.lineSequence }}
                             </h3>
+                {% endif %}
                         <h4 class="govuk-heading-s govuk-!-margin-bottom-1" data-qa="{{offence.offenceCode }}-title">{{offence.offenceCode }} - {{ offence.offenceDescription }}</h4>
                         <p class="govuk-body-s">
                             {% if (offence.offenceEndDate and offence.offenceStartDate and offence.offenceEndDate !== offence.offenceStartDate) %}


### PR DESCRIPTION
Reverts ministryofjustice/calculate-release-dates#788

Reverting as this change does not has Louise's approval.