### PR TITLE
CRS-2096 Add UT Code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,6 @@ jobs:
       tag: << pipeline.parameters.node-version >>
     steps:
       - checkout
-      - browser-tools/install-browser-tools
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,9 +60,6 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
-          name: unit tests
-          command: npm run test:ci
-      - run:
           name: "Run Unit test and Collect Coverage Reports"
           command: npm run coverage:ci
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,8 +65,10 @@ jobs:
       - run:
           name: "Run Unit test and Collect Coverage Reports"
           command: npm run coverage:ci
-      - store_artifacts:
+      - store_test_results:
           path: coverage
+      - store_artifacts:
+          path: coverage/index.html
 
   integration_test:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,7 @@ jobs:
       tag: << pipeline.parameters.node-version >>
     steps:
       - checkout
+      - browser-tools/install-browser-tools
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,10 +62,11 @@ jobs:
       - run:
           name: unit tests
           command: npm run test:ci
-      - store_test_results:
-          path: test_results
+      - run:
+          name: "Run Unit test and Collect Coverage Reports"
+          command: npm run coverage:ci
       - store_artifacts:
-          path: test_results/unit-test-reports.html
+          path: coverage
 
   integration_test:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,10 +65,8 @@ jobs:
       - run:
           name: "Run Unit test and Collect Coverage Reports"
           command: npm run coverage:ci
-      - store_test_results:
-          path: coverage
       - store_artifacts:
-          path: coverage/index.html
+          path: coverage
 
   integration_test:
     executor:

--- a/package.json
+++ b/package.json
@@ -37,8 +37,6 @@
   },
   "jest": {
     "coverageReporters": [
-      "json",
-      "lcov",
       "text",
       "html"
     ],

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "typecheck": "tsc && tsc -p integration_tests",
     "test": "jest",
     "test:ci": "jest --runInBand",
+    "coverage": "jest --collectCoverage=true",
+    "coverage:ci": "jest --collectCoverage=true --runInBand",
     "security_audit": "npx audit-ci --config audit-ci.json",
     "int-test": "cypress run --config video=false",
     "int-test-ui": "cypress open --e2e --browser chrome",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,12 @@
     "npm": "^10"
   },
   "jest": {
+    "coverageReporters": [
+      "json",
+      "lcov",
+      "text",
+      "html"
+    ],
     "transform": {
       "^.+\\.tsx?$": [
         "ts-jest",

--- a/server/routes/calculationRoutes.test.ts
+++ b/server/routes/calculationRoutes.test.ts
@@ -443,7 +443,7 @@ describe('Calculation routes tests', () => {
       .expect(200)
       .expect('Content-Type', /html/)
       .expect(res => {
-        expect(res.text).toContain('CR')
+        expect(res.text).toContain('DCR')
         expect(res.text).toContain('Conditional release date')
         expect(res.text).toContain('Wednesday, 03 February 2021')
         expect(res.text).toContain('Tuesday, 02 February 2021 when adjusted to a working day')

--- a/server/routes/calculationRoutes.test.ts
+++ b/server/routes/calculationRoutes.test.ts
@@ -443,7 +443,7 @@ describe('Calculation routes tests', () => {
       .expect(200)
       .expect('Content-Type', /html/)
       .expect(res => {
-        expect(res.text).toContain('DCR')
+        expect(res.text).toContain('CRD')
         expect(res.text).toContain('Conditional release date')
         expect(res.text).toContain('Wednesday, 03 February 2021')
         expect(res.text).toContain('Tuesday, 02 February 2021 when adjusted to a working day')

--- a/server/routes/calculationRoutes.test.ts
+++ b/server/routes/calculationRoutes.test.ts
@@ -443,7 +443,7 @@ describe('Calculation routes tests', () => {
       .expect(200)
       .expect('Content-Type', /html/)
       .expect(res => {
-        expect(res.text).toContain('CRD')
+        expect(res.text).toContain('CR')
         expect(res.text).toContain('Conditional release date')
         expect(res.text).toContain('Wednesday, 03 February 2021')
         expect(res.text).toContain('Tuesday, 02 February 2021 when adjusted to a working day')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,14 @@
     "experimentalDecorators": true,
     "typeRoots": ["./server/@types", "./node_modules/@types"]
   },
-  "exclude": ["node_modules", "assets/**/*.js", "integration_tests", "dist", "cypress.config.ts", "typings"],
+  "exclude": [
+    "node_modules",
+    "assets/**/*.js",
+    "integration_tests",
+    "dist",
+    "cypress.config.ts",
+    "typings",
+    "coverage"
+  ],
   "include": ["**/*.js", "**/*.ts"]
 }


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/CRS-2096

Using Jest to record code coverage.
Used this as a reference - https://circleci.com/docs/code-coverage/#javascript

This commit doesn't display the code coverage html page inside the artifact tab in circleci.
We just have to click on the index.html and it will open in a separate browser tab and click on links for sub html pages [Screenshots below].

https://output.circle-artifacts.com/output/job/5aa5f06d-91ab-4352-83a2-a106e03bb7a7/artifacts/0/coverage/index.html

<img width="1677" alt="Screenshot 2024-08-23 at 10 52 49" src="https://github.com/user-attachments/assets/0f67b98d-96b1-449a-91ee-c2124d61af4d">

<img width="1673" alt="Screenshot 2024-08-23 at 10 53 03" src="https://github.com/user-attachments/assets/65816842-f38e-4e02-a69e-ed7909bedee5">

