### PR TITLE
Fixing display of historic calcs

### DIFF
--- a/server/models/ComparisonResultOverviewModel.ts
+++ b/server/models/ComparisonResultOverviewModel.ts
@@ -43,11 +43,11 @@ export default class ComparisonResultOverviewModel {
 
     this.releaseDateMismatchesTable = new ReleaseDatesMismatchResultTable(comparison)
 
-    const unsupportedSentenceMismatchTypes = []
+    const unsupportedSentenceMismatchTypes = ['UNSUPPORTED_SENTENCE_TYPE']
 
     this.unsupportedSentenceMismatchesTable = new MismatchResultTable(comparison, unsupportedSentenceMismatchTypes)
 
-    const validationErrorMismatchTypes = []
+    const validationErrorMismatchTypes = ['VALIDATION_ERROR']
     this.validationErrorMismatchesTable = new MismatchResultTable(comparison, validationErrorMismatchTypes)
 
     this.status = comparison.status

--- a/server/routes/compareRoutes.ts
+++ b/server/routes/compareRoutes.ts
@@ -124,9 +124,10 @@ export default class CompareRoutes {
     const { token, userRoles, caseloadMap } = res.locals.user
     const comparison = await this.comparisonService.getPrisonComparison(bulkComparisonResultId, token)
     const allowBulkComparison = this.bulkLoadService.allowBulkComparison(userRoles)
+    const overviewModel = new ComparisonResultOverviewModel(comparison, caseloadMap)
     return res.render('pages/compare/resultOverview', {
       allowBulkComparison,
-      comparison: new ComparisonResultOverviewModel(comparison, caseloadMap),
+      comparison: overviewModel,
       bulkComparisonResultId,
     })
   }


### PR DESCRIPTION
- Set the correct defaults in the model
- Moved the ComparisonResultOverviewModel into a variable (for easier understanding and debugging locally)