### PR TITLE
Update Email Links

### DIFF
--- a/server/errorHandler.test.ts
+++ b/server/errorHandler.test.ts
@@ -26,7 +26,7 @@ describe('GET 404', () => {
       .expect(res => {
         expect(res.text).toContain('<pre>')
         expect(res.text).toContain(
-          'Email <a href="mailto:calculatereleasedates@digital.justice.gov.uk?subject=Calculate release dates - Page not found">calculatereleasedates@digital.justice.gov.uk</a>',
+          'mailto:calculatereleasedates@digital.justice.gov.uk?subject=Calculate%20release%20dates%20-%20Page%20not%20found',
         )
       })
   })
@@ -39,7 +39,7 @@ describe('GET 404', () => {
       .expect(res => {
         expect(res.text).not.toContain('<pre>')
         expect(res.text).toContain(
-          'Email <a href="mailto:calculatereleasedates@digital.justice.gov.uk?subject=Calculate release dates - Page not found">calculatereleasedates@digital.justice.gov.uk</a>',
+          'mailto:calculatereleasedates@digital.justice.gov.uk?subject=Calculate%20release%20dates%20-%20Page%20not%20found',
         )
       })
   })

--- a/server/services/manualEntryValidationService.test.ts
+++ b/server/services/manualEntryValidationService.test.ts
@@ -13,7 +13,7 @@ describe('Manual Entry Validation', () => {
   it('Should return a validation string if a pair found', () => {
     const msg = underTest.validatePairs(['ARD', 'CRD'])
     expect(msg).toBe(
-      '<div class="govuk-error-message">The following release dates cannot be selected together:<ul><li>CRD and ARD</li></ul>You must re-select the dates, or if you need help, <a href="mailto:omu.specialistsupportteam@justice.gov.uk?subject=Calculate%20release%20dates%20-%20Manual%20Entry%20-%20Incompatible%20Dates">contact the Specialist support team</a> for support.</div>',
+      '<div class="govuk-error-message">The following release dates cannot be selected together:<ul><li>CRD and ARD</li></ul>You must reselect the dates, or if you need help, <a href="mailto:omu.specialistsupportteam@justice.gov.uk?subject=Calculate%20release%20dates%20-%20Manual%20Entry%20-%20Incompatible%20Dates">contact the Specialist support team</a> for support.</div>',
     )
   })
   it('Should return undefined if there are no matches', () => {
@@ -23,7 +23,7 @@ describe('Manual Entry Validation', () => {
   it('Should show all pairs if there are more than one', () => {
     const msg = underTest.validatePairs(['ARD', 'CRD', 'HDCED', 'HDCAD', 'PRRD', 'PED', 'APD'])
     expect(msg).toBe(
-      '<div class="govuk-error-message">The following release dates cannot be selected together:<ul><li>CRD and ARD</li>\n<li>HDCED and PRRD</li>\n<li>HDCAD and PRRD</li>\n<li>PED and PRRD</li>\n<li>HDCED and PED</li>\n<li>HDCAD and PED</li>\n<li>HDCAD and APD</li></ul>You must re-select the dates, or if you need help, <a href="mailto:omu.specialistsupportteam@justice.gov.uk?subject=Calculate%20release%20dates%20-%20Manual%20Entry%20-%20Incompatible%20Dates">contact the Specialist support team</a> for support.</div>',
+      '<div class="govuk-error-message">The following release dates cannot be selected together:<ul><li>CRD and ARD</li>\n<li>HDCED and PRRD</li>\n<li>HDCAD and PRRD</li>\n<li>PED and PRRD</li>\n<li>HDCED and PED</li>\n<li>HDCAD and PED</li>\n<li>HDCAD and APD</li></ul>You must reselect the dates, or if you need help, <a href="mailto:omu.specialistsupportteam@justice.gov.uk?subject=Calculate%20release%20dates%20-%20Manual%20Entry%20-%20Incompatible%20Dates">contact the Specialist support team</a> for support.</div>',
     )
   })
 })

--- a/server/services/manualEntryValidationService.test.ts
+++ b/server/services/manualEntryValidationService.test.ts
@@ -13,7 +13,7 @@ describe('Manual Entry Validation', () => {
   it('Should return a validation string if a pair found', () => {
     const msg = underTest.validatePairs(['ARD', 'CRD'])
     expect(msg).toBe(
-      '<div class="govuk-error-message">The following release dates cannot be selected together:<ul><li>CRD and ARD</li></ul>Reselect your dates or <a href="mailto:calculatereleasedates@digital.justice.gov.uk?subject=Calculate%20release%20dates%20-%20Support">contact the Calculate release dates team</a> for support.</div>',
+      '<div class="govuk-error-message">The following release dates cannot be selected together:<ul><li>CRD and ARD</li></ul>You must re-select the dates, or if you need help, <a href="mailto:omu.specialistsupportteam@justice.gov.uk?subject=Calculate%20release%20dates%20-%20Manual%20Entry%20-%20Incompatible%20Dates">contact the Specialist support team</a> for support.</div>',
     )
   })
   it('Should return undefined if there are no matches', () => {
@@ -23,7 +23,7 @@ describe('Manual Entry Validation', () => {
   it('Should show all pairs if there are more than one', () => {
     const msg = underTest.validatePairs(['ARD', 'CRD', 'HDCED', 'HDCAD', 'PRRD', 'PED', 'APD'])
     expect(msg).toBe(
-      '<div class="govuk-error-message">The following release dates cannot be selected together:<ul><li>CRD and ARD</li>\n<li>HDCED and PRRD</li>\n<li>HDCAD and PRRD</li>\n<li>PED and PRRD</li>\n<li>HDCED and PED</li>\n<li>HDCAD and PED</li>\n<li>HDCAD and APD</li></ul>Reselect your dates or <a href="mailto:calculatereleasedates@digital.justice.gov.uk?subject=Calculate%20release%20dates%20-%20Support">contact the Calculate release dates team</a> for support.</div>',
+      '<div class="govuk-error-message">The following release dates cannot be selected together:<ul><li>CRD and ARD</li>\n<li>HDCED and PRRD</li>\n<li>HDCAD and PRRD</li>\n<li>PED and PRRD</li>\n<li>HDCED and PED</li>\n<li>HDCAD and PED</li>\n<li>HDCAD and APD</li></ul>You must re-select the dates, or if you need help, <a href="mailto:omu.specialistsupportteam@justice.gov.uk?subject=Calculate%20release%20dates%20-%20Manual%20Entry%20-%20Incompatible%20Dates">contact the Specialist support team</a> for support.</div>',
     )
   })
 })

--- a/server/services/manualEntryValidationService.ts
+++ b/server/services/manualEntryValidationService.ts
@@ -1,3 +1,5 @@
+import { createSupportLink } from '../utils/utils'
+
 const illegalPairs: Pair[] = [
   {
     left: 'CRD',
@@ -37,8 +39,13 @@ const illegalPairs: Pair[] = [
   } as Pair,
 ]
 const errorStart = 'The following release dates cannot be selected together:'
-const errorEnd =
-  'Reselect your dates or <a href="mailto:calculatereleasedates@digital.justice.gov.uk?subject=Calculate%20release%20dates%20-%20Support">contact the Calculate release dates team</a> for support.'
+const errorEnd = createSupportLink({
+  prefixText: 'You must re-select the dates, or if you need help, ',
+  linkText: 'contact the Specialist support team',
+  suffixText: ' for support.',
+  emailSubjectText: 'Calculate release dates - Manual Entry - Incompatible Dates',
+})
+
 export default class ManualEntryValidationService {
   public validatePairs(dates: string[]): string {
     if (dates === null || dates === undefined) {

--- a/server/services/manualEntryValidationService.ts
+++ b/server/services/manualEntryValidationService.ts
@@ -40,7 +40,7 @@ const illegalPairs: Pair[] = [
 ]
 const errorStart = 'The following release dates cannot be selected together:'
 const errorEnd = createSupportLink({
-  prefixText: 'You must re-select the dates, or if you need help, ',
+  prefixText: 'You must reselect the dates, or if you need help, ',
   linkText: 'contact the Specialist support team',
   suffixText: ' for support.',
   emailSubjectText: 'Calculate release dates - Manual Entry - Incompatible Dates',

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -9,7 +9,7 @@ import {
   hmppsFormatDate,
 } from 'hmpps-court-cases-release-dates-design/hmpps/utils/utils'
 import dateFilter from 'nunjucks-date-filter'
-import { hmppsDesignSystemsEnvironmentName, initialiseName } from './utils'
+import { hmppsDesignSystemsEnvironmentName, initialiseName, createSupportLink } from './utils'
 import { ApplicationInfo } from '../applicationInfo'
 import config from '../config'
 import ComparisonType from '../enumerations/comparisonType'
@@ -78,6 +78,7 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   njkEnv.addGlobal('digitalPrisonServicesUrl', config.apis.digitalPrisonServices.ui_url)
   njkEnv.addGlobal('courtCasesAndReleaseDatesUrl', config.apis.courtCasesAndReleaseDatesUi.url)
   njkEnv.addGlobal('ComparisonType', ComparisonType)
+  njkEnv.addGlobal('createSupportLink', createSupportLink)
 
   njkEnv.addFilter('initialiseName', initialiseName)
 

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,4 +1,4 @@
-import { convertToTitleCase, initialiseName } from './utils'
+import { convertToTitleCase, initialiseName, createSupportLink } from './utils'
 
 describe('convert to title case', () => {
   it.each([
@@ -26,5 +26,49 @@ describe('initialise name', () => {
     ['Double barrelled', 'Robert-John Smith-Jones-Wilson', 'R. Smith-Jones-Wilson'],
   ])('%s initialiseName(%s, %s)', (_: string, a: string, expected: string) => {
     expect(initialiseName(a)).toEqual(expected)
+  })
+})
+
+describe('createSupportLink', () => {
+  it.each([
+    [
+      'No subject or prefix/suffix',
+      { linkText: 'contact the team' },
+      '<a href="mailto:omu.specialistsupportteam@justice.gov.uk">contact the team</a>',
+    ],
+    [
+      'With subject text',
+      { linkText: 'contact the team', emailSubjectText: 'Page not found' },
+      '<a href="mailto:omu.specialistsupportteam@justice.gov.uk?subject=Page%20not%20found">contact the team</a>',
+    ],
+    [
+      'With subject and prefix',
+      {
+        prefixText: 'If you need help, ',
+        linkText: 'contact the team',
+        emailSubjectText: 'Calculate release dates - Manual entry - Incompatible dates',
+      },
+      'If you need help, <a href="mailto:omu.specialistsupportteam@justice.gov.uk?subject=Calculate%20release%20dates%20-%20Manual%20entry%20-%20Incompatible%20dates">contact the team</a>',
+    ],
+    [
+      'With subject, prefix, and suffix',
+      {
+        prefixText: 'If you need help, ',
+        linkText: 'contact the team',
+        emailSubjectText: 'Calculate release dates - Manual entry - Incompatible dates',
+        suffixText: ' for support.',
+      },
+      'If you need help, <a href="mailto:omu.specialistsupportteam@justice.gov.uk?subject=Calculate%20release%20dates%20-%20Manual%20entry%20-%20Incompatible%20dates">contact the team</a> for support.',
+    ],
+    [
+      'With different email',
+      {
+        emailAddress: 'calculatereleasedates@digital.justice.gov.uk',
+        linkText: 'contact Calculate release dates team',
+      },
+      '<a href="mailto:calculatereleasedates@digital.justice.gov.uk">contact Calculate release dates team</a>',
+    ],
+  ])('%s', (_, options, expected) => {
+    expect(createSupportLink(options)).toEqual(expected)
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -96,3 +96,23 @@ export const hmppsDesignSystemsEnvironmentName = (
   }
   return 'prod'
 }
+
+export type EmailLinkOptions = {
+  emailAddress?: string
+  linkText: string
+  emailSubjectText?: string
+  prefixText?: string
+  suffixText?: string
+}
+
+export function createSupportLink({
+  linkText,
+  prefixText = '',
+  suffixText = '',
+  emailAddress = 'omu.specialistsupportteam@justice.gov.uk',
+  emailSubjectText,
+}: EmailLinkOptions): string {
+  const subjectPart = emailSubjectText ? `?subject=${encodeURIComponent(emailSubjectText)}` : ''
+  const contactLink = `<a href="mailto:${emailAddress}${subjectPart}">${linkText}</a>`
+  return `${prefixText}${contactLink}${suffixText}`
+}

--- a/server/views/pages/accessibility.njk
+++ b/server/views/pages/accessibility.njk
@@ -1,6 +1,7 @@
 {% extends "../partials/layout.njk" %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
+
 {% set pageTitle = applicationName + " - Accessibility Statement" %}
 {% set pageId = "accessibility" %}
 
@@ -40,13 +41,23 @@
             <p class="govuk-body">The Calculate release dates service has been independently audited and is fully
                 compliant against WCAG 2.1 Level AA.</p>
             <h2 class="govuk-heading-m">Feedback and contact information</h2>
-            <p class="govuk-body">If you need information on this website in a different format, email <a
-                        href="mailto:calculatereleasedates@digital.justice.gov.uk">calculatereleasedates@digital.justice.gov.uk</a>.
-                We’ll review your request and get back to you within one working day.</p>
+            <p class="govuk-body">If you need information on this website in a different format, email
+                {{ createSupportLink({
+                    emailAddress: 'calculatereleasedates@digital.justice.gov.uk',
+                    linkText: 'calculatereleasedates@digital.justice.gov.uk',
+                    emailSubjectText: 'Request for accessible format'
+                }) | safe }}.
+                We’ll review your request and get back to you within one working day.
+            </p>
             <h2 class="govuk-heading-m">Reporting accessibility problems with this website</h2>
             <p class="govuk-body">We’re always looking to improve the accessibility of this website. If you find any
                 problems not listed on this page or think we’re not meeting accessibility requirements, contact the
-                Calculate release dates team by emailing: <a href="mailto:calculatereleasedates@digital.justice.gov.uk">calculatereleasedates@digital.justice.gov.uk</a>.
+                Calculate release dates team by emailing:
+                {{ createSupportLink({
+                    emailAddress: 'calculatereleasedates@digital.justice.gov.uk',
+                    linkText: 'calculatereleasedates@digital.justice.gov.uk',
+                    emailSubjectText: 'Accessibility issue'
+                }) | safe }}.
             </p>
             <h2 class="govuk-heading-m">Enforcement procedure</h2>
             <p class="govuk-body">The Equality and Human Rights Commission (EHRC) is responsible for enforcing the

--- a/server/views/pages/components/sds-plus-notification-banner/template.njk
+++ b/server/views/pages/components/sds-plus-notification-banner/template.njk
@@ -3,7 +3,12 @@
     <h2 class="govuk-heading-m">Important</h2>
     <p class="govuk-body">This service has identified one or more sentences where the release date is calculated at two thirds (SDS+).</p>
     <p class="govuk-body">Make sure a peach calculation sheet has been used to calculate the release dates.</p>
-    <p class="govuk-body">If a sentence has been incorrectly identified as SDS+, email <a href="mailto:calculatereleasedates@digital.justice.gov.uk">calculatereleasedates@digital.justice.gov.uk</a>.</p>
+    <p class="govuk-body">If a sentence has been incorrectly identified as SDS+, or if you need help,
+        {{ createSupportLink({
+            linkText: 'contact the Specialist support team',
+            emailSubjectText: 'Manage offences - SDS+ offence identification'
+        }) | safe }}.
+    </p>
 {% endset %}
 {{ mojBanner({
     type: ' ',

--- a/server/views/pages/error.njk
+++ b/server/views/pages/error.njk
@@ -76,8 +76,14 @@
 
                     <p class="govuk-body">If you pasted the web address, check you copied it correctly.</p>
 
-          <p class="govuk-body">Email <a href="mailto:calculatereleasedates@digital.justice.gov.uk?subject=Calculate release dates - Page not found">calculatereleasedates@digital.justice.gov.uk</a>
-              if you need support.</p>
+                    <p class="govuk-body">Email
+                        {{ createSupportLink({
+                            emailAddress: 'calculatereleasedates@digital.justice.gov.uk',
+                            linkText: 'calculatereleasedates@digital.justice.gov.uk',
+                            emailSubjectText: 'Calculate release dates - Page not found'
+                        }) | safe }}
+                        if you need support.
+                    </p>
         {% else %}
           <h1>{{ message }}</h1>
           <h2>{{ status }}</h2>

--- a/server/views/pages/partials/complete/feedbackSection.njk
+++ b/server/views/pages/partials/complete/feedbackSection.njk
@@ -5,7 +5,12 @@
     <span>This is a new service. Your feedback will help make it better. To give feedback you can:</span>
     <ul class="govuk-list govuk-!-margin-top-2">
       <li><a target="_blank" title="Provide feedback, opens in a new tab" href="https://eu.surveymonkey.com/r/Calculatereleasedatesfeedback">Complete a short survey</a></li>
-      <li><a title="Email your report of a specific problem" href="mailto:calculatereleasedates@digital.justice.gov.uk">Report a specific problem by email</a></li>
+      <li>
+        {{ createSupportLink({
+          linkText: 'Report a specific problem by email',
+          emailSubjectText: 'Calculate release dates - Improve this service - Specific issue'
+        }) | safe }}
+      </li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION

Including adding createSupportLink utility and update support link references across the application

- Introduced `createSupportLink` utility function to generate mailto links with optional subject, prefix, and suffix.
- Updated tests in `utils.test.ts` to cover various cases of `createSupportLink` usage.
- Replaced static mailto links with dynamic support links generated using `createSupportLink` in templates and error messages (e.g., `sds-plus-notification-banner`, `accessibility.njk`, and `error.njk`).
- Updated the manual entry validation service to use `createSupportLink` for consistent support link formatting.
- Modified related tests to reflect the updated support link structure in validation error messages.