### PR TITLE
CRD-2203-format-t3-exclusion

### DIFF
--- a/server/utils/nunjucksSetup.test.ts
+++ b/server/utils/nunjucksSetup.test.ts
@@ -50,6 +50,8 @@ describe('nunjucksSetup', () => {
   describe('Return valid SDS40 exclusion titles', () => {
     it('Returns the correct title for standard exclusion', () => {
       expect(formatSds40Exclusion('DOMESTIC_ABUSE')).toStrictEqual('Domestic Abuse')
+      expect(formatSds40Exclusion('SEXUAL')).toStrictEqual('Sexual')
+      expect(formatSds40Exclusion('MURDER')).toStrictEqual('Murder')
     })
     it('Returns the correct title for tranche 3 exclusion', () => {
       expect(formatSds40Exclusion('DOMESTIC_ABUSE_T3')).toStrictEqual(

--- a/server/utils/nunjucksSetup.test.ts
+++ b/server/utils/nunjucksSetup.test.ts
@@ -55,6 +55,12 @@ describe('nunjucksSetup', () => {
       expect(formatSds40Exclusion('DOMESTIC_ABUSE_T3')).toStrictEqual(
         'Domestic Abuse (for prisoners in custody on or after the 16th Dec 2024)',
       )
+      expect(formatSds40Exclusion('SEXUAL_T3')).toStrictEqual(
+        'Sexual (for prisoners in custody on or after the 16th Dec 2024)',
+      )
+      expect(formatSds40Exclusion('MURDER_T3')).toStrictEqual(
+        'Murder (for prisoners in custody on or after the 16th Dec 2024)',
+      )
     })
   })
 })

--- a/server/utils/nunjucksSetup.test.ts
+++ b/server/utils/nunjucksSetup.test.ts
@@ -1,6 +1,6 @@
 import express from 'express'
 import { ApplicationInfo } from '../applicationInfo'
-import nunjucksSetup, { pluraliseName } from './nunjucksSetup'
+import nunjucksSetup, { formatSds40Exclusion, pluraliseName } from './nunjucksSetup'
 
 describe('nunjucksSetup', () => {
   describe('design systems params', () => {
@@ -45,6 +45,16 @@ describe('nunjucksSetup', () => {
 
     it('Names without an s on the end get pluralised with apostrophe s', () => {
       expect(pluraliseName('Smith')).toStrictEqual("Smith's")
+    })
+  })
+  describe('Return valid SDS40 exclusion titles', () => {
+    it('Returns the correct title for standard exclusion', () => {
+      expect(formatSds40Exclusion('DOMESTIC_ABUSE')).toStrictEqual('Domestic Abuse')
+    })
+    it('Returns the correct title for tranche 3 exclusion', () => {
+      expect(formatSds40Exclusion('DOMESTIC_ABUSE_T3')).toStrictEqual(
+        'Domestic Abuse (for prisoners in custody on or after the 16th Dec 2024)',
+      )
     })
   })
 })

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -145,6 +145,7 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   njkEnv.addFilter('personDateOfBirth', personDateOfBirth)
   njkEnv.addFilter('personStatus', personStatus)
   njkEnv.addFilter('hmppsFormatDate', hmppsFormatDate)
+  njkEnv.addFilter('formatSds40Exclusion', formatSds40Exclusion)
 }
 
 const getReleaseDateType = (dates: { [key: string]: unknown }): string => {
@@ -195,4 +196,14 @@ export const pluraliseName = (name: string) => {
     return `${name}'`
   }
   return `${name}'s`
+}
+
+export const formatSds40Exclusion = (exclusion: string) => {
+  const isTrancheThree = exclusion.endsWith('_T3')
+  const title = exclusion
+    .replace('_T3', '')
+    .replace(/_/g, ' ')
+    .toLowerCase()
+    .replace(/\b\w/g, char => char.toUpperCase())
+  return isTrancheThree ? `${title} (for prisoners in custody on or after the 16th Dec 2024)` : title
 }

--- a/server/views/pages/partials/checkInformation/sentenceCard.njk
+++ b/server/views/pages/partials/checkInformation/sentenceCard.njk
@@ -91,7 +91,7 @@
                                     {% if featureToggles.sdsExclusionIndicatorsEnabled and sentence.hasAnSDSEarlyReleaseExclusion and sentence.hasAnSDSEarlyReleaseExclusion !== 'NO' %}
                                         <tr class="govuk-table__row govuk-body-s" data-qa="sds-early-release-exclusion">
                                             <th scope="row" class="govuk-table__header sentence-table-header">SDS40 Release Exclusion</th>
-                                            <td class="govuk-table__cell">{{ sentence.hasAnSDSEarlyReleaseExclusion | replace("_", " ") | title }}</td>
+                                            <td class="govuk-table__cell">{{ sentence.hasAnSDSEarlyReleaseExclusion | formatSds40Exclusion }}</td>
                                         </tr>
                                     {% endif %}
                                 </tbody>


### PR DESCRIPTION
If SDS40 exclusions end with _T3, exclusions is tranche three related and needs different text from the standard exclusions.

Create new njk filter to format the correct feedback.