### PR TITLE
CRS-1956-remove-override-hint-from-calc-summary

### DIFF
--- a/integration_tests/e2e/calculationSummary.cy.ts
+++ b/integration_tests/e2e/calculationSummary.cy.ts
@@ -61,6 +61,7 @@ context('Calculation summary', () => {
     calculationSummaryPage.consecutiveDatesTable().should('contain.text', '2071 days')
     calculationSummaryPage.consecutiveDatesTable().should('contain.text', '20 November 2018')
     calculationSummaryPage.consecutiveDatesTable().should('contain.text', '13 May 2017')
+    calculationSummaryPage.crdDateShouldNotNotBePresent('CRD')
 
     calculationSummaryPage.releaseDatesAdjustmentsTable().should('contain.text', '20 November 2018 minus 15 days')
     calculationSummaryPage.releaseDatesAdjustmentsTable().should('contain.text', '13 May 2017 minus 6 days')

--- a/integration_tests/mockApis/calculateReleaseDatesApi.ts
+++ b/integration_tests/mockApis/calculateReleaseDatesApi.ts
@@ -947,7 +947,7 @@ export default {
           date: dayjs().add(7, 'day').format('YYYY-MM-DD'),
           type: 'CRD',
           description: 'Conditional release date',
-          hints: [{ text: 'Friday, 05 May 2017 when adjusted to a working day' }],
+          hints: [{ text: 'Friday, 05 May 2017 when adjusted to a working day' }, { text: 'Manually overridden' }],
         },
         HDCED: {
           date: dayjs().add(3, 'day').format('YYYY-MM-DD'),

--- a/integration_tests/pages/calculationSummary.ts
+++ b/integration_tests/pages/calculationSummary.ts
@@ -29,6 +29,10 @@ export default class CalculationSummaryPage extends CalculationSummaryCommon {
     cy.get(`[data-qa=${type}-date]`).should('not.exist')
   }
 
+  public crdDateShouldNotNotBePresent(date: string) {
+    cy.get(`[data-qa=${date}-date]`).should('not.contain.text', 'Manually overridden')
+  }
+
   public changeDateLink(type: string): PageElement {
     return cy.get(`[data-qa=change-approved-${type}-link]`)
   }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -9,7 +9,7 @@ import {
   hmppsFormatDate,
 } from 'hmpps-court-cases-release-dates-design/hmpps/utils/utils'
 import dateFilter from 'nunjucks-date-filter'
-import { hmppsDesignSystemsEnvironmentName, initialiseName, createSupportLink } from './utils'
+import { hmppsDesignSystemsEnvironmentName, initialiseName, createSupportLink, validPreCalcHints } from './utils'
 import { ApplicationInfo } from '../applicationInfo'
 import config from '../config'
 import ComparisonType from '../enumerations/comparisonType'
@@ -146,6 +146,7 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   njkEnv.addFilter('personStatus', personStatus)
   njkEnv.addFilter('hmppsFormatDate', hmppsFormatDate)
   njkEnv.addFilter('formatSds40Exclusion', formatSds40Exclusion)
+  njkEnv.addFilter('validPreCalcHints', validPreCalcHints)
 }
 
 const getReleaseDateType = (dates: { [key: string]: unknown }): string => {

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -97,6 +97,9 @@ export const hmppsDesignSystemsEnvironmentName = (
   return 'prod'
 }
 
+export const validPreCalcHints = (hints: [{ html: string }]) =>
+  hints.filter(h => !h.html.includes('Manually overridden'))
+
 export type EmailLinkOptions = {
   emailAddress?: string
   linkText: string

--- a/server/views/pages/components/calculation-summary-dates-card/CalculationSummaryDatesCard.test.ts
+++ b/server/views/pages/components/calculation-summary-dates-card/CalculationSummaryDatesCard.test.ts
@@ -2,9 +2,11 @@ import nunjucks from 'nunjucks'
 import * as cheerio from 'cheerio'
 import dateFilter from 'nunjucks-date-filter'
 import CalculationSummaryDatesCardModel, { filteredListOfDates } from './CalculationSummaryDatesCardModel'
+import { validPreCalcHints } from '../../../../utils/utils'
 
 const njkEnv = nunjucks.configure([__dirname])
 njkEnv.addFilter('date', dateFilter)
+njkEnv.addFilter('validPreCalcHints', validPreCalcHints)
 
 describe('ReleaseDateType', () => {
   it('should not have some of the properties in filteredListOfDates', () => {

--- a/server/views/pages/components/calculation-summary-dates-card/template.njk
+++ b/server/views/pages/components/calculation-summary-dates-card/template.njk
@@ -7,7 +7,7 @@
         <dd class="govuk-summary-list__value"
             data-qa="{{ releaseDate.shortName }}-date">{{ releaseDate.date | date('dddd, DD MMMM YYYY') }}
             <p style="margin-top: 10px;" data-qa="{{ releaseDate.shortName }}-release-date-hints">
-                {% for hint in releaseDate.hints %}
+                {% for hint in releaseDate.hints | validPreCalcHints %}
                     {{ hint.html | safe }}
                 {% endfor %}
             </p>


### PR DESCRIPTION
Exclude Nomis override dates when viewing calculation summary page.

The override flag will be invalid once a calculation is confirmed and submitted to Nomis.