### PR TITLE
crs-2294-alt-dev-env-audit-values

### DIFF
--- a/helm_deploy/values-alt-dev.yaml
+++ b/helm_deploy/values-alt-dev.yaml
@@ -33,6 +33,11 @@ generic-service:
     GENUINE_OVERRIDES_ENABLED: "true"
     THING_TO_DO_INTERCEPT_ENABLED: "true"
 
+  namespace_secrets:
+    sqs-hmpps-audit-secret:
+      AUDIT_SQS_QUEUE_URL: 'sqs_queue_url'
+      AUDIT_SQS_QUEUE_NAME: 'sqs_queue_name'
+
   # Switches off the allow list in the DEV env only.
   allowlist: null
 


### PR DESCRIPTION
Add missing env values for alt-dev for audit queue