### PR TITLE
CRS-2308: Add PED to indeterminate manual entry

### DIFF
--- a/integration_tests/e2e/manualDatesPath.cy.ts
+++ b/integration_tests/e2e/manualDatesPath.cy.ts
@@ -33,7 +33,7 @@ context('End to end user journeys entering and modifying approved dates', () => 
     cy.task('stubGetServiceDefinitions')
   })
 
-  it('Can add some manual dates', () => {
+  it('Can add some manual dates when there are no indeterminate sentences', () => {
     cy.signIn()
     const landingPage = CCARDLandingPage.goTo('A1234AB')
     landingPage.calculateReleaseDatesAction().click()
@@ -94,6 +94,57 @@ context('End to end user journeys entering and modifying approved dates', () => 
     manualDatesConfirmationPage.dateShouldHaveValue('MTD', '09 March 2028')
     // check unselected dates are not shown
     manualDatesConfirmationPage.dateShouldNotBePresent('LTD')
+    manualDatesConfirmationPage.submitToNomisButton().click()
+
+    const calculationCompletePage = Page.verifyOnPage(CalculationCompletePage)
+
+    calculationCompletePage.title().should('contain.text', 'Calculation complete')
+  })
+
+  it('Can add some manual dates when there are some indeterminate sentences', () => {
+    cy.task('stubHasSomeIndeterminateSentences')
+    cy.signIn()
+    const landingPage = CCARDLandingPage.goTo('A1234AB')
+    landingPage.calculateReleaseDatesAction().click()
+
+    const calculationReasonPage = CalculationReasonPage.verifyOnPage(CalculationReasonPage)
+    calculationReasonPage.radioByIndex(1).check()
+    calculationReasonPage.submitReason().click()
+
+    const checkInformationUnsupportedPage = Page.verifyOnPage(CheckInformationUnsupportedPage)
+    checkInformationUnsupportedPage.manualEntryButton().click()
+
+    const manualEntryLandingPage = Page.verifyOnPage(ManualEntryLandingPage)
+    manualEntryLandingPage.continue().click()
+
+    const selectDatesPage = Page.verifyOnPage(ManualEntrySelectDatesPage)
+    selectDatesPage.expectDateOffered(['Tariff', 'TERSED', 'ROTL', 'APD', 'PED', 'None'])
+    selectDatesPage.checkDate('Tariff')
+    selectDatesPage.checkDate('ROTL')
+    selectDatesPage.checkDate('PED')
+    selectDatesPage.continue().click()
+
+    const enterSedPage = Page.verifyOnPage(ManualDatesEnterDatePage)
+    enterSedPage.checkIsFor('Tariff')
+    enterSedPage.enterDate('Tariff', '01', '06', '2026')
+    enterSedPage.continue().click()
+
+    const enterCRDPage = Page.verifyOnPage(ManualDatesEnterDatePage)
+    enterCRDPage.checkIsFor('ROTL')
+    enterCRDPage.enterDate('ROTL', '03', '09', '2027')
+    enterCRDPage.continue().click()
+
+    const enterMTDPage = Page.verifyOnPage(ManualDatesEnterDatePage)
+    enterMTDPage.checkIsFor('PED')
+    enterMTDPage.enterDate('PED', '09', '03', '2028')
+    enterMTDPage.continue().click()
+
+    const manualDatesConfirmationPage = Page.verifyOnPage(ManualDatesConfirmationPage)
+    manualDatesConfirmationPage.dateShouldHaveValue('Tariff', '01 June 2026')
+    manualDatesConfirmationPage.dateShouldHaveValue('ROTL', '03 September 2027')
+    manualDatesConfirmationPage.dateShouldHaveValue('PED', '09 March 2028')
+    // check unselected dates are not shown
+    manualDatesConfirmationPage.dateShouldNotBePresent('TERSED')
     manualDatesConfirmationPage.submitToNomisButton().click()
 
     const calculationCompletePage = Page.verifyOnPage(CalculationCompletePage)

--- a/integration_tests/mockApis/calculateReleaseDatesApi.ts
+++ b/integration_tests/mockApis/calculateReleaseDatesApi.ts
@@ -509,7 +509,7 @@ export default {
     return stubFor({
       request: {
         method: 'GET',
-        urlPattern: '/calculate-release-dates/validation/manual-entry-dates-validation\\?releaseDates=([A-Z|,]*)',
+        urlPattern: '/calculate-release-dates/validation/manual-entry-dates-validation\\?releaseDates=([A-Za-z|,]*)',
       },
       response: {
         status: 200,
@@ -1115,6 +1115,19 @@ export default {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: false,
+      },
+    })
+  },
+  stubHasSomeIndeterminateSentences: (): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/calculate-release-dates/manual-calculation/1234/has-indeterminate-sentences`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: true,
       },
     })
   },

--- a/server/services/manualEntryService.test.ts
+++ b/server/services/manualEntryService.test.ts
@@ -1,0 +1,93 @@
+import { Request } from 'express'
+import ManualEntryService from './manualEntryService'
+import DateTypeConfigurationService from './dateTypeConfigurationService'
+import DateValidationService from './dateValidationService'
+import CalculateReleaseDatesService from './calculateReleaseDatesService'
+
+jest.mock('../services/calculateReleaseDatesService')
+jest.mock('../services/dateTypeConfigurationService')
+
+describe('manualEntryService', () => {
+  const dateTypeConfigurationService = new DateTypeConfigurationService() as jest.Mocked<DateTypeConfigurationService>
+  const dateValidationService = new DateValidationService()
+  const calculateReleaseDatesService = new CalculateReleaseDatesService(
+    null,
+  ) as jest.Mocked<CalculateReleaseDatesService>
+  const manualEntryService = new ManualEntryService(
+    dateTypeConfigurationService,
+    dateValidationService,
+    calculateReleaseDatesService,
+  )
+  const token = 'token'
+  const req = { user: {}, session: {} } as Request
+
+  const mockDateConfigs = {
+    CRD: 'CRD',
+    LED: 'LED',
+    SED: 'SED',
+    NPD: 'NPD',
+    ARD: 'ARD',
+    TUSED: 'TUSED',
+    PED: 'PED',
+    SLED: 'SLED',
+    HDCED: 'HDCED',
+    NCRD: 'NCRD',
+    ETD: 'ETD',
+    MTD: 'MTD',
+    LTD: 'LTD',
+    DPRRD: 'DPRRD',
+    PRRD: 'PRRD',
+    ESED: 'ESED',
+    ERSED: 'ERSED',
+    TERSED: 'TERSED',
+    APD: 'APD',
+    HDCAD: 'HDCAD',
+    Tariff: 'Tariff',
+    ROTL: 'ROTL',
+    None: 'None',
+  }
+
+  beforeEach(() => {
+    calculateReleaseDatesService.validateDatesForManualEntry.mockResolvedValue({
+      messages: [],
+      messageType: null,
+    })
+    dateTypeConfigurationService.dateTypeToDescriptionMapping.mockResolvedValue(mockDateConfigs)
+  })
+
+  it('should provide relevant date config when there are no indeterminate sentences', async () => {
+    const { config } = await manualEntryService.verifySelectedDateType(token, req, 'A1234BC', false, true)
+    expect(config.items.map(it => it.value)).toStrictEqual([
+      'SED',
+      'LED',
+      'CRD',
+      'HDCED',
+      'TUSED',
+      'PRRD',
+      'PED',
+      'ROTL',
+      'ERSED',
+      'ARD',
+      'HDCAD',
+      'MTD',
+      'ETD',
+      'LTD',
+      'APD',
+      'NPD',
+      'DPRRD',
+    ])
+  })
+
+  it('should provide relevant date config when there are indeterminate sentences', async () => {
+    const { config } = await manualEntryService.verifySelectedDateType(token, req, 'A1234BC', true, true)
+    expect(config.items.map(it => it.value || it.divider)).toStrictEqual([
+      'Tariff',
+      'TERSED',
+      'ROTL',
+      'APD',
+      'PED',
+      'or',
+      'None',
+    ])
+  })
+})

--- a/server/services/manualEntryService.ts
+++ b/server/services/manualEntryService.ts
@@ -454,6 +454,12 @@ export default class ManualEntryService {
           text: dateTypeDefinitions.APD,
         },
         {
+          value: 'PED',
+          attributes: {},
+          checked: false,
+          text: dateTypeDefinitions.PED,
+        },
+        {
           divider: 'or',
         },
         {


### PR DESCRIPTION
When there are indeterminate sentences and a user is directed to the manual journey they can now add a PED alongside the existing date options. This is relevant when there are also determinate sentences and a PED can be set after the Tariff date.