### PR TITLE
Add support for displaying unsupportedManualMessages in manual entry journey

### DIFF
--- a/server/@types/calculateReleaseDates/index.d.ts
+++ b/server/@types/calculateReleaseDates/index.d.ts
@@ -1567,6 +1567,7 @@ export interface components {
     SupportedValidationResponse: {
       unsupportedSentenceMessages: components['schemas']['ValidationMessage'][]
       unsupportedCalculationMessages: components['schemas']['ValidationMessage'][]
+      unsupportedManualMessages: components['schemas']['ValidationMessage'][]
     }
     ThingsToDo: {
       prisonerId: string

--- a/server/models/ManualEntryLandingPageViewModel.ts
+++ b/server/models/ManualEntryLandingPageViewModel.ts
@@ -10,6 +10,7 @@ export default class ManualEntryLandingPageViewModel extends PrisonerContextView
     public validationMessages?: {
       unsupportedSentenceMessages: ValidationMessage[]
       unsupportedCalculationMessages: ValidationMessage[]
+      unsupportedManualMessages: ValidationMessage[]
     },
   ) {
     super(prisonerDetail)

--- a/server/routes/manualEntryRoutes.test.ts
+++ b/server/routes/manualEntryRoutes.test.ts
@@ -170,6 +170,7 @@ describe('Tests for /calculation/:nomsId/manual-entry', () => {
     calculateReleaseDatesService.getUnsupportedSentenceOrCalculationMessagesWithType.mockResolvedValue({
       unsupportedSentenceMessages: [],
       unsupportedCalculationMessages: [],
+      unsupportedManualMessages: [],
     })
     prisonerService.getPrisonerDetail.mockResolvedValue(stubbedPrisonerData)
     manualCalculationService.hasIndeterminateSentences.mockResolvedValue(false)
@@ -194,6 +195,7 @@ describe('Tests for /calculation/:nomsId/manual-entry', () => {
     calculateReleaseDatesService.getUnsupportedSentenceOrCalculationMessagesWithType.mockResolvedValue({
       unsupportedSentenceMessages: [],
       unsupportedCalculationMessages: [],
+      unsupportedManualMessages: [],
     })
     prisonerService.getPrisonerDetail.mockResolvedValue(stubbedPrisonerData)
     manualCalculationService.hasIndeterminateSentences.mockResolvedValue(false)
@@ -250,6 +252,7 @@ describe('Tests for /calculation/:nomsId/manual-entry', () => {
         } as ValidationMessage,
       ],
       unsupportedCalculationMessages: [],
+      unsupportedManualMessages: [],
     })
     prisonerService.getPrisonerDetail.mockResolvedValue(stubbedPrisonerData)
     manualCalculationService.hasIndeterminateSentences.mockResolvedValue(false)
@@ -285,6 +288,7 @@ describe('Tests for /calculation/:nomsId/manual-entry', () => {
         } as ValidationMessage,
       ],
       unsupportedCalculationMessages: [],
+      unsupportedManualMessages: [],
     })
     prisonerService.getPrisonerDetail.mockResolvedValue(stubbedPrisonerData)
     manualCalculationService.hasIndeterminateSentences.mockResolvedValue(true)

--- a/server/routes/manualEntryRoutes.ts
+++ b/server/routes/manualEntryRoutes.ts
@@ -60,6 +60,7 @@ export default class ManualEntryRoutes {
       new ManualEntryLandingPageViewModel(prisonerDetail, hasIndeterminateSentences, req.originalUrl, {
         unsupportedSentenceMessages: unsupportedSentenceOrCalculationMessages.unsupportedSentenceMessages,
         unsupportedCalculationMessages: unsupportedSentenceOrCalculationMessages.unsupportedCalculationMessages,
+        unsupportedManualMessages: unsupportedSentenceOrCalculationMessages.unsupportedManualMessages,
       }),
     )
   }

--- a/server/services/calculateReleaseDatesService.test.ts
+++ b/server/services/calculateReleaseDatesService.test.ts
@@ -386,6 +386,34 @@ describe('Calculate release dates service tests', () => {
   })
 
   describe('Validation tests', () => {
+    it('returns all validation messages from sentence, calculation, and manual entry', async () => {
+      const mockResponse = {
+        unsupportedSentenceMessages: [
+          { type: 'UNSUPPORTED_SENTENCE', message: 'Unsupported sentence' } as ValidationMessage,
+        ],
+        unsupportedCalculationMessages: [
+          { type: 'UNSUPPORTED_CALCULATION', message: 'Unsupported calculation' } as ValidationMessage,
+        ],
+        unsupportedManualMessages: [
+          { type: 'MANUAL_ENTRY_JOURNEY_REQUIRED', message: 'Manual input required' } as ValidationMessage,
+        ],
+      }
+
+      // Mock the API endpoint
+      fakeApi.get(`/validation/${prisonerId}/supported-validation`).reply(200, mockResponse)
+
+      const result = await calculateReleaseDatesService.getUnsupportedSentenceOrCalculationMessages(prisonerId, token)
+
+      expect(result).toHaveLength(3)
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ message: 'Unsupported sentence' }),
+          expect.objectContaining({ message: 'Unsupported calculation' }),
+          expect.objectContaining({ message: 'Manual input required' }),
+        ]),
+      )
+    })
+
     it('Test validation passes', async () => {
       fakeApi.post(`/validation/${prisonerId}/full-validation`).reply(200, validResult)
       const result = await calculateReleaseDatesService.validateBackend(prisonerId, null, token)

--- a/server/services/calculateReleaseDatesService.ts
+++ b/server/services/calculateReleaseDatesService.ts
@@ -86,6 +86,8 @@ export default class CalculateReleaseDatesService {
       combinedMessages.push(...validationMessages.unsupportedSentenceMessages.values())
     if (validationMessages.unsupportedCalculationMessages)
       combinedMessages.push(...validationMessages.unsupportedCalculationMessages.values())
+    if (validationMessages.unsupportedCalculationMessages)
+      combinedMessages.push(...validationMessages.unsupportedCalculationMessages.values())
     return combinedMessages
   }
 

--- a/server/services/calculateReleaseDatesService.ts
+++ b/server/services/calculateReleaseDatesService.ts
@@ -86,8 +86,8 @@ export default class CalculateReleaseDatesService {
       combinedMessages.push(...validationMessages.unsupportedSentenceMessages.values())
     if (validationMessages.unsupportedCalculationMessages)
       combinedMessages.push(...validationMessages.unsupportedCalculationMessages.values())
-    if (validationMessages.unsupportedCalculationMessages)
-      combinedMessages.push(...validationMessages.unsupportedCalculationMessages.values())
+    if (validationMessages.unsupportedManualMessages)
+      combinedMessages.push(...validationMessages.unsupportedManualMessages.values())
     return combinedMessages
   }
 


### PR DESCRIPTION
- Extended SupportedValidationResponse to include unsupportedManualMessages
- Passed new validation messages through service, model, and route layers
- Ensured consistency with unsupportedSentence and unsupportedCalculation message