### PR TITLE
CRS-2399: Attempt to fix alt dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,11 @@ workflows:
                 - main
       - request-preprod-approval:
           type: approval
+          requires:
+            - helm_lint
+            - unit_test
+            - integration_test
+            - build_docker
           filters:
             branches:
               only:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -79,6 +79,7 @@ jobs:
     secrets: inherit
     with:
       environment: 'alt-dev'
+      k8s_deployment_name: 'calculate-release-dates-alt-dev'
       app_version: '${{ needs.build.outputs.app_version }}'
 #  deploy_preprod:
 #    name: Deploy to the preprod environment


### PR DESCRIPTION
Set the k8s_deployment_name for alt dev.

Also make the circle CI require build etc before approval to keep pre-prod deployment working...