### PR TITLE
crs-2476-manual-journey-indeterminate-bug

### DIFF
--- a/integration_tests/e2e/manualDatesPath.cy.ts
+++ b/integration_tests/e2e/manualDatesPath.cy.ts
@@ -8,6 +8,7 @@ import ManualDatesEnterDatePage from '../pages/manualDatesEnterDatePage'
 import ManualDatesConfirmationPage from '../pages/manualDatesConfirmationPage'
 import CalculationCompletePage from '../pages/calculationComplete'
 import ManualDatesRemoveDatePage from '../pages/manualDatesRemoveDate'
+import ManualDatesNoDatesConfirmationPage from '../pages/manualDatesNoDatesConfirmationPage'
 
 context('End to end user journeys entering and modifying approved dates', () => {
   beforeEach(() => {
@@ -100,6 +101,51 @@ context('End to end user journeys entering and modifying approved dates', () => 
     const calculationCompletePage = Page.verifyOnPage(CalculationCompletePage)
 
     calculationCompletePage.title().should('contain.text', 'Calculation complete')
+  })
+
+  it('Can submit no dates for indeterminate sentences', () => {
+    cy.task('stubHasSomeIndeterminateSentences')
+    cy.signIn()
+    const landingPage = CCARDLandingPage.goTo('A1234AB')
+    landingPage.calculateReleaseDatesAction().click()
+
+    const calculationReasonPage = CalculationReasonPage.verifyOnPage(CalculationReasonPage)
+    calculationReasonPage.radioByIndex(1).check()
+    calculationReasonPage.submitReason().click()
+
+    const checkInformationUnsupportedPage = Page.verifyOnPage(CheckInformationUnsupportedPage)
+    checkInformationUnsupportedPage.manualEntryButton().click()
+
+    const manualEntryLandingPage = Page.verifyOnPage(ManualEntryLandingPage)
+    manualEntryLandingPage.continue().click()
+
+    const selectDatesPage = Page.verifyOnPage(ManualEntrySelectDatesPage)
+    selectDatesPage.expectDateOffered(['Tariff', 'TERSED', 'ROTL', 'APD', 'PED', 'None'])
+    selectDatesPage.checkDate('PED')
+    selectDatesPage.continue().click()
+
+    const enterPEDPage = Page.verifyOnPage(ManualDatesEnterDatePage)
+    enterPEDPage.checkIsFor('PED')
+    enterPEDPage.enterDate('PED', '09', '03', '2028')
+    enterPEDPage.continue().click()
+
+    const manualDatesConfirmationPage = Page.verifyOnPage(ManualDatesConfirmationPage)
+    manualDatesConfirmationPage.dateShouldHaveValue('PED', '09 March 2028')
+
+    const addAnotherDate = manualDatesConfirmationPage.addAnotherDatesLink()
+    addAnotherDate.click()
+
+    const selectDatesPageReturn = Page.verifyOnPage(ManualEntrySelectDatesPage)
+    selectDatesPageReturn.expectDateOffered(['Tariff', 'TERSED', 'ROTL', 'APD', 'PED', 'None'])
+    selectDatesPageReturn.checkDate('None')
+    selectDatesPageReturn.continue().click()
+
+    const confirmationPage = Page.verifyOnPage(ManualDatesNoDatesConfirmationPage)
+    confirmationPage.confirm()
+    confirmationPage.continue()
+
+    const calculationCompletePage = Page.verifyOnPage(CalculationCompletePage)
+    calculationCompletePage.title().should('contain.text', 'No release dates have been saved for')
   })
 
   it('Can add some manual dates when there are some indeterminate sentences', () => {

--- a/integration_tests/pages/manualDatesConfirmationPage.ts
+++ b/integration_tests/pages/manualDatesConfirmationPage.ts
@@ -20,4 +20,6 @@ export default class ManualDatesConfirmationPage extends Page {
   public removeReleaseDateLink = (type: string): PageElement => cy.get(`[data-qa=remove-manual-date-${type}]`)
 
   public submitToNomisButton = (): PageElement => cy.get('[data-qa=submit-to-nomis]')
+
+  public addAnotherDatesLink = (): PageElement => cy.get('[data-qa=add-another-release-date-link]')
 }

--- a/integration_tests/pages/manualDatesNoDatesConfirmationPage.ts
+++ b/integration_tests/pages/manualDatesNoDatesConfirmationPage.ts
@@ -1,0 +1,11 @@
+import Page, { PageElement } from './page'
+
+export default class ManualDatesNoDatesConfirmationPage extends Page {
+  constructor() {
+    super('indeterminate-no-dates-confirmation')
+  }
+
+  public confirm = (): PageElement => cy.get('[id=no-date-selection]').click()
+
+  public continue = (): PageElement => cy.get('[data-qa=no-date-selection]').click()
+}

--- a/server/routes/manualEntryRoutes.ts
+++ b/server/routes/manualEntryRoutes.ts
@@ -448,12 +448,10 @@ export default class ManualEntryRoutes {
       return res.redirect(redirect)
     }
 
-    if (
-      req.body != null &&
-      req.body['no-date-selection'] === 'yes' &&
-      req.session.selectedManualEntryDates[nomsId].length === 1 &&
-      req.session.selectedManualEntryDates[nomsId][0].dateType === 'None'
-    ) {
+    if (req.body != null && req.body['no-date-selection'] === 'yes') {
+      req.session.selectedManualEntryDates[nomsId] = [
+        { dateType: 'None', dateText: 'None of the above dates apply', date: null },
+      ]
       return res.redirect(`/calculation/${nomsId}/manual-entry/save`)
     }
     if (req.body != null && req.body['no-date-selection'] === 'no') {

--- a/server/views/pages/manualEntry/noDatesConfirmation.njk
+++ b/server/views/pages/manualEntry/noDatesConfirmation.njk
@@ -6,7 +6,7 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% set pageTitle = applicationName + " - determinite manual entry" %}
-{% set pageId = "determinite selection" %}
+{% set pageId = "indeterminate-no-dates-confirmation" %}
 
 {% block beforeContent %}
     {{ super() }}


### PR DESCRIPTION
When selecting "None of the above" from the date selection page, where selected dates already exist, the calculation refuses to save and send to Nomis.

manualEntryRoutes.ts expects one value to be present for dates (the "None" option) but previously selected dates still exist within the session data.