### PR TITLE
CRS-2449: New adjustments UI - exclude inactive adjustments

### DIFF
--- a/server/@types/calculateReleaseDates/calculateReleaseDatesClientTypes.ts
+++ b/server/@types/calculateReleaseDates/calculateReleaseDatesClientTypes.ts
@@ -37,3 +37,5 @@ export type SupportedValidationResponse = components['schemas']['SupportedValida
 export type ErsedEligibility = components['schemas']['ErsedEligibility']
 export type AdjustmentDto = components['schemas']['AdjustmentDto']
 export type AnalysedAdjustment = components['schemas']['AnalysedAdjustment']
+export type AdjustmentStatus = components['schemas']['AnalysedAdjustment']['status']
+export type AdjustmentType = components['schemas']['AnalysedAdjustment']['adjustmentType']


### PR DESCRIPTION
They are filtered in the backend but were previously filtered using the active flag in the UI so it's possible that old calculations might have included inactive adjustments.