### PR TITLE
CRS-2449: New adjustments UI - small tweaks

### DIFF
--- a/assets/scss/components/_adjustments.scss
+++ b/assets/scss/components/_adjustments.scss
@@ -5,3 +5,10 @@
   font-size: 24px;
   color: govuk-colour('dark-grey');
 }
+
+.adjustments-table-first-column {
+  width: 37%
+}
+.adjustments-table-second-column {
+  width: 38%
+}

--- a/server/views/pages/components/adjustments-tables/AdjustmentTablesModel.ts
+++ b/server/views/pages/components/adjustments-tables/AdjustmentTablesModel.ts
@@ -146,7 +146,7 @@ function toTable(
     })
   }
   totalsRow.push({
-    text: `${totalDays}${unusedDeductionsAllocation > 0 ? ` including ${unusedDeductionsAllocation} days of unused` : ''}`,
+    text: `${totalDays}${unusedDeductionsAllocation > 0 ? ` including ${unusedDeductionsAllocation} days unused` : ''}`,
     classes: 'govuk-!-font-weight-bold',
   })
   rows.push(totalsRow)
@@ -190,10 +190,10 @@ function toTaggedBailRow(
   const sentenceAndOffence = findSentenceAndOffenceBySentenceSequence(dto.sentenceSequence, sentencesAndOffences)
   return [
     {
-      html: `Court case ${sentenceAndOffence.caseSequence}${SentenceTypes.isRecall(sentenceAndOffence) ? recallBadge : ''}`,
+      html: `Court case ${sentenceAndOffence.caseSequence}`,
     },
     {
-      text: sentenceAndOffence?.caseReference ?? 'Unknown',
+      html: `${sentenceAndOffence?.caseReference ?? 'Unknown'}${SentenceTypes.isRecall(sentenceAndOffence) ? recallBadge : ''}`,
     },
     {
       text: `${dto.days}`,

--- a/server/views/pages/components/adjustments-tables/adjustmentTables.test.ts
+++ b/server/views/pages/components/adjustments-tables/adjustmentTables.test.ts
@@ -402,10 +402,10 @@ describe('Tests for adjustments tables component', () => {
     expect(taggedBailRows).toHaveLength(2)
 
     const firstRowCells = taggedBailRows.eq(0).find('td')
-    expect(firstRowCells.eq(0).html()).toStrictEqual(
-      'Court case 2<span class="moj-badge moj-badge--black govuk-!-margin-left-4">RECALL</span>',
+    expect(firstRowCells.eq(0).text()).toStrictEqual('Court case 2')
+    expect(firstRowCells.eq(1).html()).toStrictEqual(
+      'Unknown<span class="moj-badge moj-badge--black govuk-!-margin-left-4">RECALL</span>',
     )
-    expect(firstRowCells.eq(1).text()).toStrictEqual('Unknown')
     expect(firstRowCells.eq(2).text()).toStrictEqual('1')
   })
 
@@ -453,7 +453,7 @@ describe('Tests for adjustments tables component', () => {
 
     const remandTable = $('[data-qa=remand-table]')
     const remandRows = remandTable.find('tbody').find('tr')
-    expect(remandRows.eq(1).find('td').eq(2).text()).toStrictEqual('20 including 10 days of unused')
+    expect(remandRows.eq(1).find('td').eq(2).text()).toStrictEqual('20 including 10 days unused')
 
     const taggedBailTable = $('[data-qa=tagged-bail-table]')
     const taggedBailRows = taggedBailTable.find('tbody').find('tr')
@@ -498,7 +498,7 @@ describe('Tests for adjustments tables component', () => {
 
     const remandTable = $('[data-qa=remand-table]')
     const remandRows = remandTable.find('tbody').find('tr')
-    expect(remandRows.eq(1).find('td').eq(2).text()).toStrictEqual('10 including 10 days of unused')
+    expect(remandRows.eq(1).find('td').eq(2).text()).toStrictEqual('10 including 10 days unused')
 
     const taggedBailTable = $('[data-qa=tagged-bail-table]')
     const taggedBailRows = taggedBailTable.find('tbody').find('tr')
@@ -543,11 +543,11 @@ describe('Tests for adjustments tables component', () => {
 
     const remandTable = $('[data-qa=remand-table]')
     const remandRows = remandTable.find('tbody').find('tr')
-    expect(remandRows.eq(1).find('td').eq(2).text()).toStrictEqual('10 including 10 days of unused')
+    expect(remandRows.eq(1).find('td').eq(2).text()).toStrictEqual('10 including 10 days unused')
 
     const taggedBailTable = $('[data-qa=tagged-bail-table]')
     const taggedBailRows = taggedBailTable.find('tbody').find('tr')
-    expect(taggedBailRows.eq(1).find('td').eq(2).text()).toStrictEqual('10 including 5 days of unused')
+    expect(taggedBailRows.eq(1).find('td').eq(2).text()).toStrictEqual('10 including 5 days unused')
   })
 
   it('Should show deductions section and time spent in custody abroad table if there is any present', () => {

--- a/server/views/pages/components/adjustments-tables/template.njk
+++ b/server/views/pages/components/adjustments-tables/template.njk
@@ -16,10 +16,12 @@
                     captionClasses: "govuk-table__caption--s",
                     head: [
                         {
-                            text: "Dates"
+                            text: "Dates",
+                            classes: "adjustments-table-first-column"
                         },
                         {
-                            text: "Offence"
+                            text: "Offence",
+                            classes: "adjustments-table-second-column"
                         },
                         {
                             text: "Days",
@@ -38,10 +40,12 @@
                     captionClasses: "govuk-table__caption--s",
                     head: [
                         {
-                            text: "Court case"
+                            text: "Court case",
+                            classes: "adjustments-table-first-column"
                         },
                         {
-                            text: "Case reference"
+                            text: "Case reference",
+                            classes: "adjustments-table-second-column"
                         },
                         {
                             text: "Days",
@@ -60,10 +64,12 @@
                     captionClasses: "govuk-table__caption--s",
                     head: [
                         {
-                            text: "Document type"
+                            text: "Document type",
+                            classes: "adjustments-table-first-column"
                         },
                         {
-                            text: "Offence"
+                            text: "Offence",
+                            classes: "adjustments-table-second-column"
                         },
                         {
                             text: "Days",
@@ -151,10 +157,12 @@
                     captionClasses: "govuk-table__caption--s",
                     head: [
                         {
-                            text: "Dates"
+                            text: "Dates",
+                            classes: "adjustments-table-first-column"
                         },
                         {
-                            text: "Type"
+                            text: "Type",
+                            classes: "adjustments-table-second-column"
                         },
                         {
                             text: "Days",
@@ -173,10 +181,12 @@
                     captionClasses: "govuk-table__caption--s",
                     head: [
                         {
-                            text: "Dates"
+                            text: "Dates",
+                            classes: "adjustments-table-first-column"
                         },
                         {
-                            text: "Delay caused to release date"
+                            text: "Delay caused to release date",
+                            classes: "adjustments-table-second-column"
                         },
                         {
                             text: "Days",
@@ -195,10 +205,12 @@
                     captionClasses: "govuk-table__caption--s",
                     head: [
                         {
-                            text: "Court of appeal reference number"
+                            text: "Court of appeal reference number",
+                            classes: "adjustments-table-first-column"
                         },
                         {
-                            text: "Offence"
+                            text: "Offence",
+                            classes: "adjustments-table-second-column"
                         },
                         {
                             text: "Days",


### PR DESCRIPTION
Adjust column sizes, changed wording of unused deductions and moved the recall tag to the middle column for tagged bail.