### PR TITLE
CRS-2514: Show genuine overrides in Source for calculations

### DIFF
--- a/server/@types/calculateReleaseDates/index.d.ts
+++ b/server/@types/calculateReleaseDates/index.d.ts
@@ -1196,6 +1196,9 @@ export interface components {
         | 'FTR_TYPE_28_DAYS_SENTENCE_LT_12_MONTHS'
         | 'FTR_TYPE_28_DAYS_AGGREGATE_LT_12_MONTHS'
         | 'FTR_TYPE_48_DAYS_OVERLAPPING_SENTENCE'
+        | 'FTR_RTC_DATE_IN_FUTURE'
+        | 'FTR_RTC_DATE_BEFORE_SENTENCE_DATE'
+        | 'FTR_RTC_DATE_BEFORE_REVOCATION_DATE'
         | 'LASPO_AR_SENTENCE_TYPE_INCORRECT'
         | 'MORE_THAN_ONE_IMPRISONMENT_TERM'
         | 'MORE_THAN_ONE_LICENCE_TERM'
@@ -1380,9 +1383,27 @@ export interface components {
       /** @enum {string} */
       historicalTusedSource?: 'CRDS' | 'CRDS_OVERRIDDEN' | 'NOMIS' | 'NOMIS_OVERRIDDEN'
       /** @enum {string} */
-      sdsEarlyReleaseAllocatedTranche?: 'TRANCHE_0' | 'TRANCHE_1' | 'TRANCHE_2'
+      sdsEarlyReleaseAllocatedTranche?:
+        | 'TRANCHE_0'
+        | 'TRANCHE_1'
+        | 'TRANCHE_2'
+        | 'FTR_56_TRANCHE_1'
+        | 'FTR_56_TRANCHE_2'
+        | 'FTR_56_TRANCHE_3'
+        | 'FTR_56_TRANCHE_4'
+        | 'FTR_56_TRANCHE_5'
+        | 'FTR_56_TRANCHE_6'
       /** @enum {string} */
-      sdsEarlyReleaseTranche?: 'TRANCHE_0' | 'TRANCHE_1' | 'TRANCHE_2'
+      sdsEarlyReleaseTranche?:
+        | 'TRANCHE_0'
+        | 'TRANCHE_1'
+        | 'TRANCHE_2'
+        | 'FTR_56_TRANCHE_1'
+        | 'FTR_56_TRANCHE_2'
+        | 'FTR_56_TRANCHE_3'
+        | 'FTR_56_TRANCHE_4'
+        | 'FTR_56_TRANCHE_5'
+        | 'FTR_56_TRANCHE_6'
     }
     CalculationFragments: {
       breakdownHtml: string
@@ -1485,7 +1506,6 @@ export interface components {
        */
       comparisonType: 'ESTABLISHMENT_FULL' | 'MANUAL'
     }
-    /** @description Criteria used in the comparison */
     JsonNode: Record<string, never>
     Comparison: {
       comparisonShortReference: string
@@ -1654,7 +1674,7 @@ export interface components {
         | 'ERS_BREACH'
         | 'COURT_OF_APPEAL'
         | 'OTHER'
-      reasonFurtherDetail: string
+      reasonFurtherDetail?: string
     }
     GenuineOverrideCreatedResponse: {
       /** Format: int64 */
@@ -1792,6 +1812,17 @@ export interface components {
       calculationReason?: string
       /** Format: int64 */
       offenderSentCalculationId?: number
+      /** @enum {string} */
+      genuineOverrideReasonCode?:
+        | 'ORDER_OF_IMPRISONMENT_OR_WARRANT_DOES_NOT_MATCH_TRIAL_RECORD'
+        | 'TERRORISM'
+        | 'POWER_TO_DETAIN'
+        | 'CROSS_BORDER_SECTION_RELEASE_DATE'
+        | 'ADD_RELEASE_DATE_FROM_ANOTHER_BOOKING'
+        | 'ERS_BREACH'
+        | 'COURT_OF_APPEAL'
+        | 'OTHER'
+      genuineOverrideReasonDescription?: string
     }
     GenuineOverrideReasonResponse: {
       code: string
@@ -1962,6 +1993,7 @@ export interface components {
         | 'SDS_EARLY_RELEASE_APPLIES'
         | 'ADJUSTED_AFTER_TRANCHE_COMMENCEMENT'
         | 'BOTUS_LATEST_TUSED_USED'
+        | 'BOTUS_LATEST_TUSED_USED_POST_REPEAL'
       )[]
       /** @description Adjustments details associated that are specifically added as part of a rule */
       rulesWithExtraAdjustments: {
@@ -2106,6 +2138,17 @@ export interface components {
         | 'MANUAL_INDETERMINATE'
         | 'CALCULATED_WITH_APPROVED_DATES'
         | 'GENUINE_OVERRIDE'
+      /** @enum {string} */
+      genuineOverrideReasonCode?:
+        | 'ORDER_OF_IMPRISONMENT_OR_WARRANT_DOES_NOT_MATCH_TRIAL_RECORD'
+        | 'TERRORISM'
+        | 'POWER_TO_DETAIN'
+        | 'CROSS_BORDER_SECTION_RELEASE_DATE'
+        | 'ADD_RELEASE_DATE_FROM_ANOTHER_BOOKING'
+        | 'ERS_BREACH'
+        | 'COURT_OF_APPEAL'
+        | 'OTHER'
+      genuineOverrideReasonDescription?: string
     }
     ReleaseDatesAndCalculationContext: {
       calculation: components['schemas']['CalculationContext']
@@ -2300,7 +2343,16 @@ export interface components {
         | 'BREAKDOWN_CHANGED_SINCE_LAST_CALCULATION'
         | 'UNSUPPORTED_CALCULATION_BREAKDOWN'
       /** @enum {string} */
-      tranche?: 'TRANCHE_0' | 'TRANCHE_1' | 'TRANCHE_2'
+      tranche?:
+        | 'TRANCHE_0'
+        | 'TRANCHE_1'
+        | 'TRANCHE_2'
+        | 'FTR_56_TRANCHE_1'
+        | 'FTR_56_TRANCHE_2'
+        | 'FTR_56_TRANCHE_3'
+        | 'FTR_56_TRANCHE_4'
+        | 'FTR_56_TRANCHE_5'
+        | 'FTR_56_TRANCHE_6'
     }
     ExternalSentenceId: {
       /** Format: int32 */

--- a/server/models/ViewRouteSentenceAndOffenceViewModel.ts
+++ b/server/models/ViewRouteSentenceAndOffenceViewModel.ts
@@ -49,6 +49,7 @@ export default class ViewRouteSentenceAndOffenceViewModel {
     public calculationReason?: CalculationReason,
     public calculationDate?: string,
     adjustmentsDtos?: AnalysedAdjustment[] | AdjustmentDto[],
+    public genuineOverrideReasonDescription?: string,
   ) {
     this.adjustments = new ViewRouteAdjustmentsViewModel(adjustments, sentencesAndOffences)
     this.cases = Array.from(

--- a/server/models/calculation/CalculationSummaryViewModel.ts
+++ b/server/models/calculation/CalculationSummaryViewModel.ts
@@ -30,6 +30,7 @@ export default class CalculationSummaryViewModel {
     public approvedDates?: { [key: string]: string },
     public detailedCalculationResults?: DetailedCalculationResults,
     public hasGenuineOverridesAccess?: boolean,
+    public genuineOverrideReasonDescription?: string,
   ) {
     // intentionally left blank
   }

--- a/server/routes/viewRoutes.ts
+++ b/server/routes/viewRoutes.ts
@@ -102,6 +102,7 @@ export default class ViewRoutes {
               ? undefined
               : longDateFormat(detailedCalculationResults.context.calculationDate),
             adjustmentDtos,
+            detailedCalculationResults.context.genuineOverrideReasonDescription,
           ),
           calculationRequestId,
           nomsId,
@@ -152,7 +153,7 @@ export default class ViewRoutes {
         null,
         false,
         true,
-        null,
+        detailedCalculationResults.context.calculationType,
         detailedCalculationResults.context.calculationReference,
         hasErsed,
         null,
@@ -172,6 +173,7 @@ export default class ViewRoutes {
         undefined,
         detailedCalculationResults,
         hasGenuineOverridesAccess(userRoles),
+        detailedCalculationResults.context.genuineOverrideReasonDescription,
       )
     }
     const hasNone = detailedCalculationResults.dates.None !== undefined
@@ -200,6 +202,7 @@ export default class ViewRoutes {
       approvedDates,
       detailedCalculationResults,
       hasGenuineOverridesAccess(userRoles),
+      detailedCalculationResults.context.genuineOverrideReasonDescription,
     )
   }
 
@@ -281,6 +284,7 @@ export default class ViewRoutes {
           null,
           null,
           adjustmentsDtos,
+          null,
         ),
         calculationRequestId,
         nomsId,

--- a/server/views/pages/ccardIndex.njk
+++ b/server/views/pages/ccardIndex.njk
@@ -40,15 +40,19 @@
                         {% set latestCalc = calculationHistory[0] %}
 
                         {% set calculationDate = latestCalc.calculationDate %}
+                        {% set calculationType = latestCalc.calculationType %}
                         {% set source = "Calculate release dates service" %}
                         {% if latestCalc.calculationSource === 'NOMIS' %}
                             {% set source = "NOMIS" %}
-                        {% elseif latestCalc.calculationType and latestCalc.calculationType.startsWith("MANUAL") %}
+                        {% elseif latestCalc.calculationType and calculationType.startsWith("MANUAL") %}
                             {% set source = "Paper calculation" %}
+                        {% elseif latestCalc.calculationType and calculationType === 'GENUINE_OVERRIDE' %}
+                            {% set source = "User Override" %}
                         {% endif %}
 
                         {% set establishment = latestCalc.establishment or "Not entered" %}
                         {% set reason = latestCalc.calculationReason or "Not entered" %}
+                        {% set genuineOverrideReasonDescription = latestCalc.genuineOverrideReasonDescription %}
 
                         {% include "./partials/calculationSummary/summary.njk" %}
                         {% include "./partials/calculationSummary/minimalCalculationCard.njk" %}

--- a/server/views/pages/partials/calculationHistory/calculationHistory.njk
+++ b/server/views/pages/partials/calculationHistory/calculationHistory.njk
@@ -1,9 +1,12 @@
 {% macro addCalculationRow(calculation, rowNum) %}
+    {% set calculationType = calculation.calculationType %}
     {% if calculation.calculationSource === 'NOMIS' %}
         {% set source = "NOMIS" %}
     {% else %}
-        {% if calculation.calculationType.startsWith("MANUAL") %}
+        {% if calculationType.startsWith("MANUAL") %}
             {% set source = "Paper calculation" %}
+        {% elseif calculationType === 'GENUINE_OVERRIDE' %}
+            {% set source = "User Override" %}
         {% else %}
             {% set source = "Calculate release dates service" %}
         {% endif %}
@@ -32,6 +35,8 @@
         <td class="govuk-table__cell">{{ source }}
             {% if source === 'Paper calculation' %}
                 <br/><span class="govuk-!-font-size-16 govuk-hint">Entered in the Calculate release dates service</span>
+            {% elseif calculationType === 'GENUINE_OVERRIDE' %}
+                <br/><span class="govuk-!-font-size-16 govuk-hint">{{ calculation.genuineOverrideReasonDescription }}</span>
             {% endif %}
         </td>
     </tr>

--- a/server/views/pages/partials/calculationSummary/summary.njk
+++ b/server/views/pages/partials/calculationSummary/summary.njk
@@ -33,6 +33,8 @@
             {% if source === 'Paper calculation' %}
                 <br/>
                 <span class="govuk-!-font-size-16 govuk-hint">Entered in the Calculate release dates service</span>
+            {% elseif calculationType === 'GENUINE_OVERRIDE' %}
+                <br/> <span class="govuk-!-font-size-16 govuk-hint">{{ genuineOverrideReasonDescription }}</span>
             {% endif %}
         </dd>
     </div>

--- a/server/views/pages/view/calculationSummary.njk
+++ b/server/views/pages/view/calculationSummary.njk
@@ -33,6 +33,7 @@
             <h1 class="govuk-heading-xl">Calculation details</h1>
 
             {% set isManualCalc = (model.calculationType != null) and (model.calculationType.startsWith("MANUAL")) %}
+            {% set isGenuineOverride = (model.calculationType != null) and (model.calculationType === "GENUINE_OVERRIDE") %}
 
             {% if model.calculationReason.isOther %}
                 {% set reason = "Other (" + model.otherReasonDescription + ")" %}
@@ -45,7 +46,17 @@
                 {% if model.calculationSource === 'NOMIS' %}
                     {% set source = "NOMIS" %}
                 {% elseif isManualCalc %}
-                    {% set source = "Paper calculation <br/><span class=\"govuk-!-font-size-16 govuk-hint\">Entered in the Calculate release dates service</span>" | safe %}
+                    {% set source %}
+                        Paper calculation
+                        <br>
+                        <span class="govuk-!-font-size-16 govuk-hint">Entered in the Calculate release dates service</span>
+                    {% endset %}
+                {% elseif isGenuineOverride %}
+                    {% set source %}
+                        User Override
+                        <br>
+                        <span class="govuk-!-font-size-16 govuk-hint">{{ model.genuineOverrideReasonDescription }}</span>
+                    {% endset %}
                 {% endif %}
                 {{ govukSummaryList({
                     classes: "govuk-summary-list--no-border",
@@ -80,7 +91,8 @@
                                 classes: "custom-summary-list__key"
                             },
                             value: {
-                                text: source
+                                html: source,
+                                classes: "summary-source-value"
                             }
                         }]
                 }) }}

--- a/server/views/pages/view/sentencesAndOffences.njk
+++ b/server/views/pages/view/sentencesAndOffences.njk
@@ -29,12 +29,23 @@
             {% endif %}
 
             {% set isManualCalc = (model.calculationType != null) and (model.calculationType.startsWith("MANUAL")) %}
+            {% set isGenuineOverride = (model.calculationType != null) and (model.calculationType === "GENUINE_OVERRIDE") %}
 
             {% set source = "Calculate release dates service" %}
             {% if model.calculationSource === 'NOMIS' %}
                 {% set source = "NOMIS" %}
             {% elseif isManualCalc %}
-                {% set source = "Paper calculation <br/><span class=\"govuk-!-font-size-16 govuk-hint\">Entered in the Calculate release dates service</span>" | safe %}
+                {% set source %}
+                    Paper calculation
+                    <br>
+                    <span class="govuk-!-font-size-16 govuk-hint">Entered in the Calculate release dates service</span>
+                {% endset %}
+            {% elseif isGenuineOverride %}
+                {% set source %}
+                    User Override
+                    <br>
+                    <span class="govuk-!-font-size-16 govuk-hint">{{ model.genuineOverrideReasonDescription }}</span>
+                {% endset %}
             {% endif %}
 
             {% if model.calculationReason|length %}
@@ -74,7 +85,8 @@
                             classes: "custom-summary-list__key"
                         },
                         value: {
-                            text: source
+                            html: source,
+                            classes: 'summary-source-value'
                         }
                         }]
                 }) }}


### PR DESCRIPTION
Source in the following places now shows User Override and the reason for override if it was a GO.
 * latest calc on the home page
 * calculation history table
 * view calculation sentence and offence details
 * view calculation summary details