### PR TITLE
CRS-2668: Add prisonId to validation-failures-requiring-fix event

### DIFF
--- a/server/services/checkInformationService.test.ts
+++ b/server/services/checkInformationService.test.ts
@@ -149,6 +149,7 @@ describe('checkInformationService', () => {
         prisonerNumber: nomsId,
         username: 'user1',
         isUnsupported: true,
+        prisonId: 'LEI',
       },
     })
   })
@@ -194,6 +195,7 @@ describe('checkInformationService', () => {
         prisonerNumber: nomsId,
         username: 'user1',
         isUnsupported: false,
+        prisonId: 'LEI',
       },
     })
   })
@@ -225,6 +227,7 @@ describe('checkInformationService', () => {
         prisonerNumber: nomsId,
         username: 'user1',
         isUnsupported: false,
+        prisonId: 'LEI',
       },
     })
   })

--- a/server/services/checkInformationService.ts
+++ b/server/services/checkInformationService.ts
@@ -63,6 +63,7 @@ export default class CheckInformationService {
     }
 
     if (validationMessages?.messages?.length) {
+      const prisonId = prisonerDetail?.agencyId || null
       this.telemetryClient?.trackEvent({
         name: 'validation-failures-requiring-fix',
         properties: {
@@ -70,6 +71,7 @@ export default class CheckInformationService {
           prisonerNumber: nomsId,
           username,
           isUnsupported,
+          ...(prisonId && { prisonId }),
         },
       })
     }


### PR DESCRIPTION
To match the new common field on request and other telemetry