### PR TITLE
CRS-2711: Attempt to resolve front end components 401s

### DIFF
--- a/server/data/frontendComponentsApiClient.ts
+++ b/server/data/frontendComponentsApiClient.ts
@@ -1,4 +1,4 @@
-import { asSystem, RestClient } from '@ministryofjustice/hmpps-rest-client'
+import { RestClient } from '@ministryofjustice/hmpps-rest-client'
 import { AuthenticationClient } from '@ministryofjustice/hmpps-auth-clients'
 import FrontendComponent from '../models/FrontendComponent'
 import config from '../config'
@@ -9,17 +9,14 @@ export default class FrontendComponentsApiClient extends RestClient {
     super('Frontend Components API', config.apis.frontendComponents, logger, authenticationClient)
   }
 
-  async getComponents<T extends AvailableComponent[]>(
+  getComponents<T extends AvailableComponent[]>(
     components: T,
-    authToken: string,
+    userToken: string,
   ): Promise<Record<T[number], FrontendComponent>> {
-    return this.get<Record<T[number], FrontendComponent>>(
-      {
-        path: `/components`,
-        query: `component=${components.join('&component=')}`,
-        headers: { 'x-user-token': authToken },
-      },
-      asSystem(),
-    )
+    return this.get({
+      path: `/components`,
+      query: `component=${components.join('&component=')}`,
+      headers: { 'x-user-token': userToken },
+    })
   }
 }

--- a/server/middleware/setUpDPSFrontendComponents.ts
+++ b/server/middleware/setUpDPSFrontendComponents.ts
@@ -3,7 +3,7 @@ import { Services } from '../services'
 import logger from '../../logger'
 
 export default function setUpFrontendComponents({ frontEndComponentService }: Services): RequestHandler {
-  return async (req, res, next) => {
+  return async (_, res, next) => {
     try {
       const { header } = await frontEndComponentService.getComponents(['header'], res.locals.user.token)
 

--- a/server/services/frontEndComponentsService.ts
+++ b/server/services/frontEndComponentsService.ts
@@ -7,7 +7,7 @@ export default class FrontEndComponentsService {
     this.frontEndComponentsApiClient = frontEndComponentsApiClient
   }
 
-  async getComponents(components: AvailableComponent[], authToken: string) {
-    return this.frontEndComponentsApiClient.getComponents(components, authToken)
+  async getComponents(components: AvailableComponent[], userToken: string) {
+    return this.frontEndComponentsApiClient.getComponents(components, userToken)
   }
 }


### PR DESCRIPTION
We don't actually need to provide any additional auth as FE components relies only on the x-user-token header.