### PR TITLE
CRS-2778: Change progression model exclusion label

### DIFF
--- a/server/views/pages/partials/checkInformation/sentenceCard.njk
+++ b/server/views/pages/partials/checkInformation/sentenceCard.njk
@@ -115,7 +115,7 @@
                                         {% endif %}
                                         {% if sentence.sdsDescriptions.progressionModelExclusionDescription %}
                                             <tr class="govuk-table__row govuk-body-s" data-qa="sds-progression-model-early-release-exclusion">
-                                                <th scope="row" class="govuk-table__header sentence-table-header">Progression model exclusion</th>
+                                                <th scope="row" class="govuk-table__header sentence-table-header">Progression model does not apply to</th>
                                                 <td class="govuk-table__cell">{{ sentence.sdsDescriptions.progressionModelExclusionDescription }}</td>
                                             </tr>
                                         {% endif %}


### PR DESCRIPTION
because release policy didn’t want Schedule 13 part 3 and ‘would be SDS+’ to be seen as exclusions