### PR TITLE
CRS-2805: Fix app traces

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -28,7 +28,7 @@ import getPrisoner from './middleware/getPrisoner'
 import maintenanceMiddleware from './middleware/maintenanceMiddleware'
 import config from './config'
 import logger from '../logger'
-import addUsernameAndCaseloadToTelemetry from './utils/azureAppInsights'
+import addUsernameAndCaseloadToTelemetry from './utils/appInsightsCustomTelemetry'
 
 export default function createApp(services: Services): express.Application {
   const app = express()

--- a/server/utils/appInsightsCustomTelemetry.ts
+++ b/server/utils/appInsightsCustomTelemetry.ts
@@ -1,0 +1,15 @@
+import { telemetry } from '@ministryofjustice/hmpps-azure-telemetry'
+import type { RequestHandler } from 'express'
+
+export default function addUsernameAndCaseloadToTelemetry(): RequestHandler {
+  return (req, res, next) => {
+    const { username } = res?.locals?.user || {}
+    const caseloadId = req?.prisoner?.agencyId || null
+
+    telemetry.setSpanAttributes({
+      ...(username && { username }),
+      ...(caseloadId && { caseloadId }),
+    })
+    return next()
+  }
+}

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -1,6 +1,4 @@
 import { flushTelemetry, initialiseTelemetry, telemetry } from '@ministryofjustice/hmpps-azure-telemetry'
-import type { RequestHandler } from 'express'
-import logger from '../../logger'
 
 initialiseTelemetry({
   serviceName: 'calculate-release-dates',
@@ -14,24 +12,10 @@ initialiseTelemetry({
   .addModifier(telemetry.processors.enrichSpanNameWithHttpRoute())
   .startRecording()
 
-const shutdown = async (signal: string) => {
-  logger.info(`${signal} received, shutting down...`)
+const shutdown = async () => {
   await flushTelemetry()
   process.exit(0)
 }
 
-process.on('SIGTERM', () => shutdown('SIGTERM'))
-process.on('SIGINT', () => shutdown('SIGINT'))
-
-export default function addUsernameAndCaseloadToTelemetry(): RequestHandler {
-  return (req, res, next) => {
-    const { username } = res?.locals?.user || {}
-    const caseloadId = req?.prisoner?.agencyId || null
-
-    telemetry.setSpanAttributes({
-      ...(username && { username }),
-      ...(caseloadId && { caseloadId }),
-    })
-    return next()
-  }
-}
+process.on('SIGTERM', () => shutdown())
+process.on('SIGINT', () => shutdown())


### PR DESCRIPTION
The logger being initialised in azureAppInsights was causing the bunyan logs not to be written to AppTraces in app insights.

Removed the log as per the template project.

Also moved the custom dimensions to ensure that any express instrumentation also happens.