### PR TITLE
crs-2804-fix-hdcad-validation

### DIFF
--- a/server/services/manualEntryService.test.ts
+++ b/server/services/manualEntryService.test.ts
@@ -141,6 +141,15 @@ describe('manualEntryService', () => {
       expect(validationMessages.messages).toEqual([])
     })
 
+    it('should not add a validation message if HDCED is within existing dates when adding HDCAD', () => {
+      const existingDates: ManualJourneySelectedDate[] = [{ dateType: 'HDCED', position: 0, completed: false }]
+      const selectedDateTypes = ['HDCAD']
+      const firstLoad = false
+      const validationMessages: ErrorMessages = { messages: [], messageType: null }
+      manualEntryService.validateHdcadWithHdced(existingDates, selectedDateTypes, firstLoad, validationMessages)
+      expect(validationMessages.messages).toEqual([])
+    })
+
     it('should not add a validation message if HDCAD is selected on first load', () => {
       const existingDates: ManualJourneySelectedDate[] = []
       const selectedDateTypes = ['HDCAD']

--- a/server/services/manualEntryService.ts
+++ b/server/services/manualEntryService.ts
@@ -179,7 +179,8 @@ export default class ManualEntryService {
   ) {
     const isHdcadSelected =
       existingDates.some(d => d.dateType === 'HDCAD') || (selectedDateTypes.includes('HDCAD') && !firstLoad)
-    const isHdcedSelected = selectedDateTypes.includes('HDCED')
+
+    const isHdcedSelected = selectedDateTypes.includes('HDCED') || existingDates.some(d => d.dateType === 'HDCED')
 
     if (isHdcadSelected && !isHdcedSelected) {
       validationMessages.messages.push({


### PR DESCRIPTION
Check for existing dates when validating existance of HDCED when adding HDCAD on the manual journey.