### PR TITLE
CRS-2824: Fix express manual when no latest calc

### DIFF
--- a/server/routes/manualEntryRoutes.test.ts
+++ b/server/routes/manualEntryRoutes.test.ts
@@ -11,7 +11,7 @@ import {
   PrisonApiSentenceDetail,
 } from '../@types/prisonApi/prisonClientTypes'
 import CalculateReleaseDatesService from '../services/calculateReleaseDatesService'
-import { ValidationMessage } from '../@types/calculateReleaseDates/calculateReleaseDatesClientTypes'
+import { LatestCalculation, ValidationMessage } from '../@types/calculateReleaseDates/calculateReleaseDatesClientTypes'
 import ManualCalculationService from '../services/manualCalculationService'
 import ManualEntryService from '../services/manualEntryService'
 import DateTypeConfigurationService from '../services/dateTypeConfigurationService'
@@ -317,6 +317,76 @@ describe('Tests for /calculation/:nomsId/manual-entry', () => {
         expect(manualEntryTitle.text().trim()).toStrictEqual('Enter the dates manually')
         expect(res.text).toContain('The unsupported sentence type is:')
         expect(res.text).toContain('This type of sentence is a not supported')
+      })
+  })
+
+  it('GET manual express when can load previous calc', () => {
+    const populateExistingDatesSpy = jest.spyOn(manualEntryService, 'populateExistingDates')
+    manualCalculationService.hasRecallSentences.mockResolvedValue(false)
+    calculateReleaseDatesService.getUnsupportedSentenceOrCalculationMessages.mockResolvedValue([
+      {
+        type: 'UNSUPPORTED_SENTENCE',
+      } as ValidationMessage,
+    ])
+    calculateReleaseDatesService.getUnsupportedSentenceOrCalculationMessagesWithType.mockResolvedValue({
+      unsupportedSentenceMessages: [
+        {
+          type: 'UNSUPPORTED_SENTENCE',
+          message: 'This type of sentence is a not supported.',
+        } as ValidationMessage,
+      ],
+      unsupportedCalculationMessages: [],
+      unsupportedManualMessages: [],
+    })
+    prisonerService.getPrisonerDetail.mockResolvedValue(stubbedPrisonerData)
+    manualCalculationService.hasIndeterminateSentences.mockResolvedValue(true)
+    calculateReleaseDatesService.offenderHasPreviousManualCalculation.mockResolvedValue(true)
+    calculateReleaseDatesService.getLatestCalculationForPrisoner.mockResolvedValue({
+      source: 'NOMIS',
+      dates: [{ type: 'CRD', date: '2000-01-01' }],
+    } as LatestCalculation)
+
+    return request(app)
+      .get('/calculation/A1234AA/manual-entry')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(populateExistingDatesSpy).toHaveBeenCalled()
+      })
+  })
+
+  it('GET manual express when cannot load previous calc', () => {
+    const populateExistingDatesSpy = jest.spyOn(manualEntryService, 'populateExistingDates')
+    manualCalculationService.hasRecallSentences.mockResolvedValue(false)
+    calculateReleaseDatesService.getUnsupportedSentenceOrCalculationMessages.mockResolvedValue([
+      {
+        type: 'UNSUPPORTED_SENTENCE',
+      } as ValidationMessage,
+    ])
+    calculateReleaseDatesService.getUnsupportedSentenceOrCalculationMessagesWithType.mockResolvedValue({
+      unsupportedSentenceMessages: [
+        {
+          type: 'UNSUPPORTED_SENTENCE',
+          message: 'This type of sentence is a not supported.',
+        } as ValidationMessage,
+      ],
+      unsupportedCalculationMessages: [],
+      unsupportedManualMessages: [],
+    })
+    prisonerService.getPrisonerDetail.mockResolvedValue(stubbedPrisonerData)
+    manualCalculationService.hasIndeterminateSentences.mockResolvedValue(true)
+    calculateReleaseDatesService.offenderHasPreviousManualCalculation.mockResolvedValue(true)
+    calculateReleaseDatesService.getLatestCalculationForPrisoner.mockRejectedValue({
+      status: 404,
+      message: 'Not Found',
+    })
+
+    return request(app)
+      .get('/calculation/A1234AA/manual-entry')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(populateExistingDatesSpy).not.toHaveBeenCalled()
       })
   })
 

--- a/server/routes/manualEntryRoutes.ts
+++ b/server/routes/manualEntryRoutes.ts
@@ -63,11 +63,15 @@ export default class ManualEntryRoutes {
 
     if (existingManualJourney && !this.existingDatesInSession(req, nomsId)) {
       if (req.session.selectedManualEntryDates == null) req.session.selectedManualEntryDates = {}
-      const latestCalculation = await this.calculateReleaseDatesService.getLatestCalculationForPrisoner(
-        nomsId,
-        username,
-      )
-      this.manualEntryService.populateExistingDates(req, nomsId, latestCalculation.dates)
+      const latestCalculation = await this.calculateReleaseDatesService
+        .getLatestCalculationForPrisoner(nomsId, username)
+        .catch((error: { status?: number; responseStatus?: number }): null | never => {
+          if ((error.status ?? error.responseStatus) === 404) {
+            return null // No latest record found / No previous calculations
+          }
+          throw error
+        })
+      if (latestCalculation) this.manualEntryService.populateExistingDates(req, nomsId, latestCalculation.dates)
     }
 
     req.session.unchangedManualJourney = existingManualJourney


### PR DESCRIPTION
This only happens if it was the very first calc and failed to write to NOMIS meaning the db state is out of sync with latest calc.