### PR TITLE
CRS-2828: Progression model exclusion update

### DIFF
--- a/server/@types/calculateReleaseDates/index.d.ts
+++ b/server/@types/calculateReleaseDates/index.d.ts
@@ -2018,8 +2018,15 @@ export interface components {
     SDSDescriptions: {
       /** @description Any reason this sentence might be excluded from SDS40 */
       sds40ExclusionDescription?: string | null
-      /** @description Any reason this sentence might be excluded from Progression Model */
+      /**
+       * @deprecated
+       * @description DEPRECATED - Use progressionModelDoesNotApplyDescription and progressionModelExcludedOffenceDescription
+       */
       progressionModelExclusionDescription?: string | null
+      /** @description Any reason this sentence might be excluded from Progression Model */
+      progressionModelDoesNotApplyDescription?: string | null
+      /** @description If this offence is excluded from progression model */
+      progressionModelExcludedOffenceDescription?: string | null
       /**
        * @description The way to display SDS plus status for the sentence
        * @enum {string|null}

--- a/server/routes/check-information/checkInformationController.test.ts
+++ b/server/routes/check-information/checkInformationController.test.ts
@@ -635,7 +635,7 @@ describe('CheckInformationController', () => {
           isSDSPlus: false,
           hasAnSDSEarlyReleaseExclusion: 'NO',
           sdsDescriptions: {
-            progressionModelExclusionDescription: 'Would be S250+',
+            progressionModelDoesNotApplyDescription: 'Would be S250+',
           },
         } as AnalysedSentenceAndOffence,
         {
@@ -683,17 +683,75 @@ describe('CheckInformationController', () => {
           expect(sexualOffenceCard.find('[data-qa=sds-40-early-release-exclusion]').text()).toContain(
             'Sexual (if sentenced after blah)',
           )
-          expect(sexualOffenceCard.find('[data-qa=sds-progression-model-early-release-exclusion]')).toHaveLength(0)
+          expect(sexualOffenceCard.find('[data-qa=sds-progression-model-does-not-apply]')).toHaveLength(0)
+          expect(sexualOffenceCard.find('[data-qa=sds-progression-model-offence-exclusion]')).toHaveLength(0)
 
           const progressionModelOffenceCard = $('.new-sentence-card:contains("PMOFFENCE")')
           expect(progressionModelOffenceCard.find('[data-qa=sds-40-early-release-exclusion]')).toHaveLength(0)
-          expect(
-            progressionModelOffenceCard.find('[data-qa=sds-progression-model-early-release-exclusion]').text(),
-          ).toContain('Would be S250+')
+          expect(progressionModelOffenceCard.find('[data-qa=sds-progression-model-does-not-apply]').text()).toContain(
+            'Would be S250+',
+          )
 
           const noExclusionCard = $('.new-sentence-card:contains("No exclusion offence")')
           expect(noExclusionCard.find('[data-qa=sds-40-early-release-exclusion]')).toHaveLength(0)
-          expect(noExclusionCard.find('[data-qa=sds-progression-model-early-release-exclusion]')).toHaveLength(0)
+          expect(noExclusionCard.find('[data-qa=sds-progression-model-does-not-apply]')).toHaveLength(0)
+        })
+    })
+
+    it('GET /calculation/:nomsId/check-information should show progression model does not apply and offence exclusions', () => {
+      const sentencesAndOffencesWithSDSDescriptions = [
+        {
+          terms: [
+            {
+              years: 3,
+            },
+          ],
+          sentenceTypeDescription: 'SDS Standard Sentence',
+          caseSequence: 1,
+          lineSequence: 1,
+          caseReference: 'CASE001',
+          courtDescription: 'Court 1',
+          sentenceSequence: 1,
+          offence: { offenceEndDate: '2021-02-03', offenceDescription: 'PMOFFENCE' },
+          sentenceAndOffenceAnalysis: 'NEW',
+          isSDSPlus: true,
+          hasAnSDSEarlyReleaseExclusion: 'NO',
+          sdsDescriptions: {
+            progressionModelDoesNotApplyDescription: 'Some reason does not apply',
+            progressionModelExcludedOffenceDescription: 'Some PM excluded offence',
+          },
+        } as AnalysedSentenceAndOffence,
+      ]
+
+      calculateReleaseDatesService.getUnsupportedSentenceOrCalculationMessages.mockResolvedValue(stubbedEmptyMessages)
+      userInputService.isCalculationReasonSet.mockReturnValue(true)
+
+      const model = new SentenceAndOffenceViewModel(
+        stubbedPrisonerData,
+        stubbedUserInput,
+        sentencesAndOffencesWithSDSDescriptions,
+        false,
+        true,
+        false,
+        stubbedReturnToCustodyDate,
+        null,
+        [],
+      )
+      checkInformationService.checkInformation.mockResolvedValue(model)
+      return request(app)
+        .get('/calculation/A1234AA/check-information')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          const $ = cheerio.load(res.text)
+          const progressionModelOffenceCard = $('.new-sentence-card:contains("PMOFFENCE")')
+          expect(progressionModelOffenceCard.find('[data-qa=sds-40-early-release-exclusion]')).toHaveLength(0)
+          expect(progressionModelOffenceCard.find('[data-qa=sds-progression-model-does-not-apply]').text()).toContain(
+            'Some reason does not apply',
+          )
+          expect(
+            progressionModelOffenceCard.find('[data-qa=sds-progression-model-offence-exclusion]').text(),
+          ).toContain('Some PM excluded offence')
         })
     })
 

--- a/server/routes/view/ViewSentencesAndOffencesController.test.ts
+++ b/server/routes/view/ViewSentencesAndOffencesController.test.ts
@@ -497,7 +497,7 @@ describe('View Sentences and Offences controller tests', () => {
         hasAnSDSEarlyReleaseExclusion: 'PROGRESSION_MODEL_SCHEDULE_13_PART_3',
         sentenceAndOffenceAnalysis: 'SAME',
         sdsDescriptions: {
-          progressionModelExclusionDescription: 'Would be SDS+',
+          progressionModelDoesNotApplyDescription: 'Would be SDS+',
         },
       } as AnalysedSentenceAndOffence,
       {
@@ -532,17 +532,17 @@ describe('View Sentences and Offences controller tests', () => {
         const $ = cheerio.load(res.text)
         const sexualOffenceCard = $('.sentence-card:contains("SXOFFENCE")')
         expect(sexualOffenceCard.find('[data-qa=sds-40-early-release-exclusion]').text()).toContain('Sexual')
-        expect(sexualOffenceCard.find('[data-qa=sds-progression-model-early-release-exclusion]')).toHaveLength(0)
+        expect(sexualOffenceCard.find('[data-qa=sds-progression-model-does-not-apply]')).toHaveLength(0)
 
         const progressionModelOffenceCard = $('.sentence-card:contains("PMOFFENCE")')
         expect(progressionModelOffenceCard.find('[data-qa=sds-40-early-release-exclusion]')).toHaveLength(0)
-        expect(
-          progressionModelOffenceCard.find('[data-qa=sds-progression-model-early-release-exclusion]').text(),
-        ).toContain('Would be SDS+')
+        expect(progressionModelOffenceCard.find('[data-qa=sds-progression-model-does-not-apply]').text()).toContain(
+          'Would be SDS+',
+        )
 
         const noExclusionCard = $('.sentence-card:contains("No exclusion offence")')
         expect(noExclusionCard.find('[data-qa=sds-40-early-release-exclusion]')).toHaveLength(0)
-        expect(noExclusionCard.find('[data-qa=sds-progression-model-early-release-exclusion]')).toHaveLength(0)
+        expect(noExclusionCard.find('[data-qa=sds-progression-model-does-not-apply]')).toHaveLength(0)
       })
   })
 

--- a/server/views/pages/partials/checkInformation/sentenceCard.njk
+++ b/server/views/pages/partials/checkInformation/sentenceCard.njk
@@ -113,10 +113,16 @@
                                                 <td class="govuk-table__cell">{{ sentence.sdsDescriptions.sds40ExclusionDescription }}</td>
                                             </tr>
                                         {% endif %}
-                                        {% if sentence.sdsDescriptions.progressionModelExclusionDescription %}
-                                            <tr class="govuk-table__row govuk-body-s" data-qa="sds-progression-model-early-release-exclusion">
+                                        {% if sentence.sdsDescriptions.progressionModelDoesNotApplyDescription %}
+                                            <tr class="govuk-table__row govuk-body-s" data-qa="sds-progression-model-does-not-apply">
                                                 <th scope="row" class="govuk-table__header sentence-table-header">Progression model does not apply to</th>
-                                                <td class="govuk-table__cell">{{ sentence.sdsDescriptions.progressionModelExclusionDescription }}</td>
+                                                <td class="govuk-table__cell">{{ sentence.sdsDescriptions.progressionModelDoesNotApplyDescription }}</td>
+                                            </tr>
+                                        {% endif %}
+                                        {% if sentence.sdsDescriptions.progressionModelExcludedOffenceDescription %}
+                                            <tr class="govuk-table__row govuk-body-s" data-qa="sds-progression-model-offence-exclusion">
+                                                <th scope="row" class="govuk-table__header sentence-table-header">Progression model exclusion</th>
+                                                <td class="govuk-table__cell">{{ sentence.sdsDescriptions.progressionModelExcludedOffenceDescription }}</td>
                                             </tr>
                                         {% endif %}
                                     {% else %}


### PR DESCRIPTION
Now separated into two fields. One for "does not apply" which is things like would be SDS+ or Schedule 13 Part 3 prior to PM commencement and one for "exclusions" which are excluded offence codes.  Both can appear in the case of an S250 with an excluded offence code.