### PR TITLE
crs-2826-approved-dates-validation

### DIFF
--- a/server/routes/approvedDatesRoutes.test.ts
+++ b/server/routes/approvedDatesRoutes.test.ts
@@ -15,7 +15,7 @@ import DateTypeConfigurationService from '../services/dateTypeConfigurationServi
 import { expectMiniProfile } from './testutils/layoutExpectations'
 import ManualEntryService from '../services/manualEntryService'
 import SessionSetup from './testutils/sessionSetup'
-import { StorageResponseModel } from '../services/dateValidationService'
+import DateValidationService, { StorageResponseModel } from '../services/dateValidationService'
 import config from '../config'
 import { testDateTypeDefinitions } from '../testutils/createUserToken'
 import { FullPageError } from '../types/FullPageError'
@@ -43,7 +43,12 @@ const calculateReleaseDatesService = new CalculateReleaseDatesService(
   auditService,
   null,
 ) as jest.Mocked<CalculateReleaseDatesService>
-const manualEntryService = new ManualEntryService(dateTypeConfigurationService, null, calculateReleaseDatesService)
+const dateValidationService = new DateValidationService() as jest.Mocked<DateValidationService>
+const manualEntryService = new ManualEntryService(
+  dateTypeConfigurationService,
+  dateValidationService,
+  calculateReleaseDatesService,
+)
 
 jest.mock('../services/prisonerService')
 
@@ -162,6 +167,17 @@ describe('Check access tests', () => {
 })
 
 describe('approvedDatesRoutes', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+    nock.cleanAll()
+  })
+  beforeEach(() => {
+    jest.spyOn(dateValidationService, 'singleItemsErrored').mockReturnValue(undefined)
+    jest.spyOn(dateValidationService, 'isDateValid').mockReturnValue(true)
+    jest.spyOn(dateValidationService, 'notWithinOneHundredYears').mockReturnValue(undefined)
+    jest.spyOn(dateValidationService, 'validateAgainstOtherDates').mockReturnValue(undefined)
+  })
+
   it('GET /calculation/:nomsId/:calculationRequestId/approved-dates-question asks the question', () => {
     prisonerService.getPrisonerDetail.mockResolvedValue(stubbedPrisonerData)
     return request(app)
@@ -461,6 +477,73 @@ describe('approvedDatesRoutes', () => {
           '/calculation/A1234AA/cancelCalculation?redirectUrl=/calculation/A1234AA/123456/submit-dates?year=2029&month=09&day=23',
         )
       })
+  })
+
+  it('POST/ /calculation/:nomsId/:calculationRequestId/submit-dates calls validation service with submitted HDCAD and existing HDCED date within calculation', () => {
+    const nomsId = 'A1234AA'
+    sessionSetup.sessionDoctor = req => {
+      req.session.selectedApprovedDates = {}
+      req.session.selectedApprovedDates[nomsId] = [
+        {
+          position: 1,
+          dateType: 'HDCAD',
+          completed: false,
+          manualEntrySelectedDate: {
+            dateType: 'HDCAD',
+            dateText: 'HDCAD',
+            date: { day: 1, month: 1, year: 2017 },
+          },
+        } as ManualJourneySelectedDate,
+      ]
+      req.session.HDCED = {}
+      req.session.HDCED[nomsId] = '2018-01-01'
+    }
+
+    prisonerService.getPrisonerDetail.mockResolvedValue(stubbedPrisonerData)
+
+    const expectedManualDates: ManualJourneySelectedDate[] = [
+      {
+        position: 1,
+        dateType: 'HDCAD',
+        completed: false,
+        manualEntrySelectedDate: {
+          dateType: 'HDCAD',
+          dateText: 'HDCAD',
+          date: { day: 1, month: 1, year: 2017 },
+        },
+        date: { day: 1, month: 1, year: 2017 },
+      } as ManualJourneySelectedDate,
+      {
+        position: 4,
+        dateType: 'HDCED',
+        completed: true,
+        manualEntrySelectedDate: {
+          dateType: 'HDCED',
+          dateText: 'HDCED',
+          date: { day: 1, month: 1, year: 2018 },
+        },
+      },
+    ]
+
+    const storeDateSpy = jest.spyOn(manualEntryService, 'storeDate')
+
+    return request(app)
+      .post('/calculation/A1234AA/123456/submit-dates?dateType=HDCAD')
+      .type('form')
+      .send({
+        day: '1',
+        month: '1',
+        year: '2017',
+        dateType: 'HDCAD',
+      })
+      .expect(() =>
+        expect(storeDateSpy).toHaveBeenCalledWith(expectedManualDates, {
+          day: '1',
+          month: '1',
+          year: '2017',
+          dateType: 'HDCAD',
+        }),
+      )
   })
 
   it('POST /calculation/:nomsId/:calculationRequestId/submit-dates loads submit dates page with mini profile if storing fails', () => {

--- a/server/routes/approvedDatesRoutes.ts
+++ b/server/routes/approvedDatesRoutes.ts
@@ -188,8 +188,34 @@ export default class ApprovedDatesRoutes {
 
     const prisonerDetail = req.prisoner
     const dateValue: EnteredDate = req.body
-    const storeDateResponse = this.manualEntryService.storeDate(req.session.selectedApprovedDates[nomsId], dateValue)
+
+    // if calculation contains HDCED, amend approved dates prior to validation. HDCAD is relative to HDCED where present.
     const approvedDates: ManualJourneySelectedDate[] = req.session.selectedApprovedDates[nomsId]
+    const existingHdced = req?.session?.HDCED?.[nomsId]
+      ? (() => {
+          const dateObject = DateTime.fromISO(req.session.HDCED[nomsId])
+          return {
+            position: 4,
+            completed: true,
+            dateType: 'HDCED' as const,
+            manualEntrySelectedDate: {
+              dateText: 'HDCED',
+              dateType: 'HDCED' as const,
+              date: {
+                day: dateObject.day,
+                month: dateObject.month,
+                year: dateObject.year,
+              },
+            },
+          }
+        })()
+      : null
+
+    if (existingHdced) {
+      approvedDates.push(existingHdced)
+    }
+
+    const storeDateResponse = this.manualEntryService.storeDate(approvedDates, dateValue)
 
     if (!storeDateResponse.success && storeDateResponse.message) {
       const { date, message, enteredDate } = storeDateResponse

--- a/server/routes/approvedDatesRoutes.ts
+++ b/server/routes/approvedDatesRoutes.ts
@@ -189,8 +189,8 @@ export default class ApprovedDatesRoutes {
     const prisonerDetail = req.prisoner
     const dateValue: EnteredDate = req.body
 
-    // if calculation contains HDCED, amend approved dates prior to validation. HDCAD is relative to HDCED where present.
     const approvedDates: ManualJourneySelectedDate[] = req.session.selectedApprovedDates[nomsId]
+
     const existingHdced = req?.session?.HDCED?.[nomsId]
       ? (() => {
           const dateObject = DateTime.fromISO(req.session.HDCED[nomsId])
@@ -211,11 +211,11 @@ export default class ApprovedDatesRoutes {
         })()
       : null
 
-    if (existingHdced) {
-      approvedDates.push(existingHdced)
-    }
-
-    const storeDateResponse = this.manualEntryService.storeDate(approvedDates, dateValue)
+    // if calculation contains HDCED, amend approved dates prior to validation. HDCAD is relative to HDCED where present.
+    const storeDateResponse = this.manualEntryService.storeDate(
+      existingHdced ? approvedDates.concat(existingHdced) : approvedDates,
+      dateValue,
+    )
 
     if (!storeDateResponse.success && storeDateResponse.message) {
       const { date, message, enteredDate } = storeDateResponse


### PR DESCRIPTION
Include HDCED from original calculation where approved dates journey is triggered. HDCAD need validating against HDCED if present.